### PR TITLE
feat: validate MCP tool-call arguments against inputSchema

### DIFF
--- a/.claude/rules/template-sync.md
+++ b/.claude/rules/template-sync.md
@@ -29,6 +29,7 @@ The script invocation in the workflow step above is authoritative. Adding or rem
 |---|---|---|
 | identical | `templates/mcp-shared/mcpserver_core.sh` | `plugins/dev-tooling/shared/mcpserver_core.sh` |
 | identical | `templates/mcp-shared/mcpserver_core.sh` | `plugins/gh-tooling/shared/mcpserver_core.sh` |
+| identical | `templates/mcp-shared/mcpserver_core.sh` | `plugins/test-writing/shared/mcpserver_core.sh` |
 | identical | `templates/mcp-shared/config.sh` | `plugins/dev-tooling/shared/config.sh` |
 | identical | `templates/mcp-shared/environment.sh` | `plugins/dev-tooling/shared/environment.sh` |
 | identical | `templates/mcp-shared/docker-compose.sh` | `plugins/dev-tooling/shared/docker-compose.sh` |

--- a/.claude/rules/template-sync.md
+++ b/.claude/rules/template-sync.md
@@ -28,6 +28,7 @@ The script invocation in the workflow step above is authoritative. Adding or rem
 | Mode | Template | Consumer |
 |---|---|---|
 | identical | `templates/mcp-shared/mcpserver_core.sh` | `plugins/dev-tooling/shared/mcpserver_core.sh` |
+| identical | `templates/mcp-shared/mcpserver_core.sh` | `plugins/gh-tooling/shared/mcpserver_core.sh` |
 | identical | `templates/mcp-shared/config.sh` | `plugins/dev-tooling/shared/config.sh` |
 | identical | `templates/mcp-shared/environment.sh` | `plugins/dev-tooling/shared/environment.sh` |
 | identical | `templates/mcp-shared/docker-compose.sh` | `plugins/dev-tooling/shared/docker-compose.sh` |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           .github/scripts/validate-template-sync.sh \
             identical templates/mcp-shared/mcpserver_core.sh   plugins/dev-tooling/shared/mcpserver_core.sh \
+            identical templates/mcp-shared/mcpserver_core.sh   plugins/gh-tooling/shared/mcpserver_core.sh \
+            identical templates/mcp-shared/mcpserver_core.sh   plugins/test-writing/shared/mcpserver_core.sh \
             identical templates/mcp-shared/config.sh           plugins/dev-tooling/shared/config.sh \
             identical templates/mcp-shared/environment.sh      plugins/dev-tooling/shared/environment.sh \
             identical templates/mcp-shared/docker-compose.sh   plugins/dev-tooling/shared/docker-compose.sh \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ claude plugin validate .
 .bats/bats-core/bin/bats plugin-tests/**/*.bats
 ```
 
-Tests are in `plugin-tests/<category>/<plugin-name>/` mirroring plugin structure.
+Tests are in `plugin-tests/<plugin-name>/` mirroring plugin structure. Tests for shared templates under `templates/mcp-shared/` (e.g. the `mcpserver_core.sh` argument validator) live in `plugin-tests/mcp-shared/` and source the template directly, since every plugin copy is kept byte-identical to it by the template-sync CI check.
 
 ### Pre-release Checklist
 - [ ] `claude plugin validate .` passes

--- a/plugin-tests/mcp-shared/mcp_argument_validation.bats
+++ b/plugin-tests/mcp-shared/mcp_argument_validation.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# bats file_tags=mcp-core,argument-validation
+# Tests for the shared mcpserver_core argument validator:
+#   validate_tool_arguments() and its wiring into handle_tools_call().
+# Enforces `required` always, and `additionalProperties: false` when declared.
+# Sources the template source of truth (templates/mcp-shared/mcpserver_core.sh);
+# every plugin copy is kept byte-identical to it by the template-sync CI check,
+# so this one suite covers the validator in all consuming plugins.
+bats_require_minimum_version 1.11.0
+
+load "${BATS_TEST_DIRNAME}/../test_helper/common_setup"
+
+setup() {
+    MCP_LOG_FILE="${BATS_TEST_TMPDIR}/server.log"
+    MCP_EXTRA_LOG_FILE=""
+    MCP_CONFIG_FILE="/dev/null"
+    MCP_TOOLS_LIST_FILE="${BATS_TEST_TMPDIR}/tools.json"
+    PROJECT_ROOT="${BATS_TEST_TMPDIR}"
+    export MCP_LOG_FILE MCP_EXTRA_LOG_FILE MCP_CONFIG_FILE MCP_TOOLS_LIST_FILE PROJECT_ROOT
+
+    # Fixture tool list:
+    #   strict — required:[number], additionalProperties:false
+    #   loose  — no required, additionalProperties unset (defaults to allowed)
+    cat > "${MCP_TOOLS_LIST_FILE}" <<'JSON'
+{
+  "tools": [
+    {
+      "name": "strict",
+      "inputSchema": {
+        "type": "object",
+        "required": ["number"],
+        "properties": { "number": {"type": "string"}, "repo": {"type": "string"} },
+        "additionalProperties": false
+      }
+    },
+    {
+      "name": "loose",
+      "inputSchema": {
+        "type": "object",
+        "properties": { "a": {"type": "string"} }
+      }
+    }
+  ]
+}
+JSON
+
+    source "${REPO_ROOT}/templates/mcp-shared/mcpserver_core.sh"
+
+    # A dispatchable stub that echoes a marker so dispatch can be observed.
+    tool_strict() { printf 'DISPATCHED:%s\n' "$1"; }
+}
+
+teardown() {
+    unset MCP_LOG_FILE MCP_EXTRA_LOG_FILE MCP_CONFIG_FILE MCP_TOOLS_LIST_FILE PROJECT_ROOT
+}
+
+# --- validate_tool_arguments: direct unit behavior ---
+
+@test "validate_tool_arguments: missing required field fails with its name" {
+    run validate_tool_arguments "strict" '{"repo": "a/b"}'
+    assert_failure
+    assert_output --partial "Missing required parameter(s): number"
+}
+
+@test "validate_tool_arguments: unknown field fails and lists allowed parameters" {
+    run validate_tool_arguments "strict" '{"number": "5", "pr": 339}'
+    assert_failure
+    assert_output --partial "Unknown parameter(s): pr"
+    assert_output --partial "Allowed parameters: number, repo"
+}
+
+@test "validate_tool_arguments: valid arguments pass with no output" {
+    run validate_tool_arguments "strict" '{"number": "5", "repo": "a/b"}'
+    assert_success
+    assert_output ""
+}
+
+@test "validate_tool_arguments: unknown field allowed when additionalProperties is unset" {
+    run validate_tool_arguments "loose" '{"a": "x", "anything": "y"}'
+    assert_success
+    assert_output ""
+}
+
+@test "validate_tool_arguments: tool absent from the schema list is not validated" {
+    run validate_tool_arguments "nonexistent" '{"whatever": 1}'
+    assert_success
+    assert_output ""
+}
+
+# --- handle_tools_call: wiring (validation runs before dispatch) ---
+
+@test "handle_tools_call: invalid arguments return an isError result, not a dispatch" {
+    local params
+    params=$(jq -n -c '{name: "strict", arguments: {repo: "a/b"}}')
+    run handle_tools_call 1 "$params"
+    assert_success
+    assert_output --partial '"isError":true'
+    assert_output --partial "Missing required parameter(s): number"
+    refute_output --partial "DISPATCHED"
+}
+
+@test "handle_tools_call: valid arguments are dispatched to the tool" {
+    local params
+    params=$(jq -n -c '{name: "strict", arguments: {number: "5"}}')
+    run handle_tools_call 1 "$params"
+    assert_success
+    assert_output --partial "DISPATCHED"
+    assert_output --partial '"isError":false'
+}

--- a/plugins/dev-tooling/.claude-plugin/plugin.json
+++ b/plugins/dev-tooling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tooling",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "description": "Three MCP servers for PHP and JavaScript operations plus an optional PHP language server. PHP (php-tooling): PHPStan, ECS, Rector, PHPUnit, PHPUnit coverage gap analysis, Symfony Console. Administration (js-admin-tooling): ESLint, Stylelint, Prettier, Jest, TypeScript, Vite builds. Storefront (js-storefront-tooling): ESLint, Stylelint, Jest, Webpack builds. LSP (opt-in): phpactor for PHP, routed through a Python URI-rewriting proxy for containerized environments. Includes SessionStart hook that injects MCP tool directives and PreToolUse hooks that enforce MCP tool usage by blocking bash commands. Supports native, Docker, Docker Compose, Vagrant and DDEV environments.",
   "author": {
     "name": "Shopware Labs"

--- a/plugins/dev-tooling/CHANGELOG.md
+++ b/plugins/dev-tooling/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.14.0] - 2026-06-25
+
+### Added
+- Tool-call arguments are now validated against the called tool's declared `inputSchema` before dispatch. Every field listed in `required` must be present, and when the schema sets `additionalProperties: false` any field outside `properties` is rejected — the call returns an `isError` result naming the missing or unknown parameters instead of running the tool. Applies to all three servers (`php-tooling`, `js-admin-tooling`, `js-storefront-tooling`); tools without a schema are left unvalidated. Added as `validate_tool_arguments` in the shared `mcpserver_core.sh`.
+
 ## [3.13.1] - 2026-04-19
 
 ### Changed

--- a/plugins/dev-tooling/shared/mcpserver_core.sh
+++ b/plugins/dev-tooling/shared/mcpserver_core.sh
@@ -114,6 +114,49 @@ handle_tools_list() {
     create_response "$id" "$result"
 }
 
+# Validate call arguments against the tool's declared inputSchema.
+# Enforces `required` (every listed field must be present) and, when the schema
+# sets `additionalProperties: false`, rejects any field not in `properties`.
+# Tools without a schema (or with an unreadable tools list) are not validated.
+# Args: $1 = tool name, $2 = arguments JSON object
+# On violation: prints a human-readable message to stdout and returns 1.
+validate_tool_arguments() {
+    local tool_name="$1"
+    local arguments="$2"
+
+    local tools_config schema
+    tools_config=$(read_json_file "$MCP_TOOLS_LIST_FILE")
+    schema=$(echo "$tools_config" | jq -c --arg n "$tool_name" \
+        '(.tools[]? | select(.name == $n) | .inputSchema) // empty' 2>/dev/null || true)
+    [[ -z "$schema" || "$schema" == "null" ]] && return 0
+
+    local message
+    message=$(jq -n -r \
+        --argjson schema "$schema" \
+        --argjson args "$arguments" \
+        '
+        ($schema.required // [])               as $req
+        | ($args | keys)                        as $present
+        | (($schema.properties // {}) | keys)   as $allowed
+        | [ $req[]     | . as $r | select(($present | index($r)) == null) ] as $missing
+        | ( if ($schema.additionalProperties == false)
+            then [ $present[] | . as $p | select(($allowed | index($p)) == null) ]
+            else [] end )                        as $unknown
+        | if   ($missing | length) > 0 then
+            "Missing required parameter(s): " + ($missing | join(", ")) + "."
+          elif ($unknown | length) > 0 then
+            "Unknown parameter(s): " + ($unknown | join(", "))
+            + ". Allowed parameters: " + ($allowed | join(", ")) + "."
+          else "" end
+        ' 2>/dev/null || true)
+
+    if [[ -n "$message" ]]; then
+        printf '%s' "$message"
+        return 1
+    fi
+    return 0
+}
+
 handle_tools_call() {
     local id="$1"
     local params="$2"
@@ -135,6 +178,17 @@ handle_tools_call() {
     local func_name="tool_${tool_name}"
     if ! type "$func_name" &>/dev/null; then
         create_error_response "$id" -32601 "Tool not found: $tool_name"
+        return
+    fi
+
+    local validation_error
+    if ! validation_error=$(validate_tool_arguments "$tool_name" "$arguments"); then
+        log "ERROR" "Tool $tool_name argument validation failed: $validation_error"
+        local invalid_result
+        invalid_result=$(jq -n -c \
+            --arg text "$validation_error" \
+            '{"content": [{"type": "text", "text": $text}], "isError": true}')
+        create_response "$id" "$invalid_result"
         return
     fi
 

--- a/plugins/gh-tooling/.claude-plugin/plugin.json
+++ b/plugins/gh-tooling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-tooling",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "GitHub CLI MCP servers wrapping gh for pull requests, issues, CI runs, jobs, commits, search, labels, projects, and reviews. Read server (always active) with 29 tools and write server (opt-in) with 23 tools. Includes SessionStart hook that injects MCP tool directives and PreToolUse hooks that enforce MCP tool usage. Configuration-optional: works without config when gh is authenticated.",
   "author": {
     "name": "Shopware Labs"

--- a/plugins/gh-tooling/CHANGELOG.md
+++ b/plugins/gh-tooling/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-06-25
+
+### Added
+- Tool-call arguments are now validated server-side against the called tool's declared `inputSchema` before dispatch, on both the read and write servers. Every `required` field must be present, and when the schema sets `additionalProperties: false` any field outside `properties` is rejected — returned as an `isError` result naming the offending parameters. This adds `required`-field enforcement and moves unknown-field rejection into the server itself, complementing the MCP-layer `additionalProperties: false` checks added in 3.1.0. Tools without a schema are left unvalidated. Added as `validate_tool_arguments` in the shared `mcpserver_core.sh`.
+
 ## [3.3.0] - 2026-06-25
 
 ### Changed

--- a/plugins/gh-tooling/shared/mcpserver_core.sh
+++ b/plugins/gh-tooling/shared/mcpserver_core.sh
@@ -114,6 +114,49 @@ handle_tools_list() {
     create_response "$id" "$result"
 }
 
+# Validate call arguments against the tool's declared inputSchema.
+# Enforces `required` (every listed field must be present) and, when the schema
+# sets `additionalProperties: false`, rejects any field not in `properties`.
+# Tools without a schema (or with an unreadable tools list) are not validated.
+# Args: $1 = tool name, $2 = arguments JSON object
+# On violation: prints a human-readable message to stdout and returns 1.
+validate_tool_arguments() {
+    local tool_name="$1"
+    local arguments="$2"
+
+    local tools_config schema
+    tools_config=$(read_json_file "$MCP_TOOLS_LIST_FILE")
+    schema=$(echo "$tools_config" | jq -c --arg n "$tool_name" \
+        '(.tools[]? | select(.name == $n) | .inputSchema) // empty' 2>/dev/null || true)
+    [[ -z "$schema" || "$schema" == "null" ]] && return 0
+
+    local message
+    message=$(jq -n -r \
+        --argjson schema "$schema" \
+        --argjson args "$arguments" \
+        '
+        ($schema.required // [])               as $req
+        | ($args | keys)                        as $present
+        | (($schema.properties // {}) | keys)   as $allowed
+        | [ $req[]     | . as $r | select(($present | index($r)) == null) ] as $missing
+        | ( if ($schema.additionalProperties == false)
+            then [ $present[] | . as $p | select(($allowed | index($p)) == null) ]
+            else [] end )                        as $unknown
+        | if   ($missing | length) > 0 then
+            "Missing required parameter(s): " + ($missing | join(", ")) + "."
+          elif ($unknown | length) > 0 then
+            "Unknown parameter(s): " + ($unknown | join(", "))
+            + ". Allowed parameters: " + ($allowed | join(", ")) + "."
+          else "" end
+        ' 2>/dev/null || true)
+
+    if [[ -n "$message" ]]; then
+        printf '%s' "$message"
+        return 1
+    fi
+    return 0
+}
+
 handle_tools_call() {
     local id="$1"
     local params="$2"
@@ -135,6 +178,17 @@ handle_tools_call() {
     local func_name="tool_${tool_name}"
     if ! type "$func_name" &>/dev/null; then
         create_error_response "$id" -32601 "Tool not found: $tool_name"
+        return
+    fi
+
+    local validation_error
+    if ! validation_error=$(validate_tool_arguments "$tool_name" "$arguments"); then
+        log "ERROR" "Tool $tool_name argument validation failed: $validation_error"
+        local invalid_result
+        invalid_result=$(jq -n -c \
+            --arg text "$validation_error" \
+            '{"content": [{"type": "text", "text": $text}], "isError": true}')
+        create_response "$id" "$invalid_result"
         return
     fi
 

--- a/plugins/shopware-env/.claude-plugin/plugin.json
+++ b/plugins/shopware-env/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shopware-env",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Bootstrap and maintain Shopware development environments. Lifecycle MCP tools for dependencies, database, frontend builds, and plugin management.",
   "author": { "name": "Martin Bens", "email": "m.bens@shopware.com" },
   "license": "MIT",

--- a/plugins/shopware-env/CHANGELOG.md
+++ b/plugins/shopware-env/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-25
+
+### Added
+- Tool-call arguments are now validated against the called tool's declared `inputSchema` before dispatch. Every field listed in `required` must be present, and when the schema sets `additionalProperties: false` any field outside `properties` is rejected — the call returns an `isError` result naming the missing or unknown parameters instead of running the tool. Applies to the `lifecycle-tooling` server; tools without a schema are left unvalidated. Added as `validate_tool_arguments` in the shared `mcpserver_core.sh` (kept byte-identical to the `templates/mcp-shared/` source).
+
 ## [1.1.1] - 2026-05-13
 
 ### Changed

--- a/plugins/shopware-env/shared/mcpserver_core.sh
+++ b/plugins/shopware-env/shared/mcpserver_core.sh
@@ -114,6 +114,49 @@ handle_tools_list() {
     create_response "$id" "$result"
 }
 
+# Validate call arguments against the tool's declared inputSchema.
+# Enforces `required` (every listed field must be present) and, when the schema
+# sets `additionalProperties: false`, rejects any field not in `properties`.
+# Tools without a schema (or with an unreadable tools list) are not validated.
+# Args: $1 = tool name, $2 = arguments JSON object
+# On violation: prints a human-readable message to stdout and returns 1.
+validate_tool_arguments() {
+    local tool_name="$1"
+    local arguments="$2"
+
+    local tools_config schema
+    tools_config=$(read_json_file "$MCP_TOOLS_LIST_FILE")
+    schema=$(echo "$tools_config" | jq -c --arg n "$tool_name" \
+        '(.tools[]? | select(.name == $n) | .inputSchema) // empty' 2>/dev/null || true)
+    [[ -z "$schema" || "$schema" == "null" ]] && return 0
+
+    local message
+    message=$(jq -n -r \
+        --argjson schema "$schema" \
+        --argjson args "$arguments" \
+        '
+        ($schema.required // [])               as $req
+        | ($args | keys)                        as $present
+        | (($schema.properties // {}) | keys)   as $allowed
+        | [ $req[]     | . as $r | select(($present | index($r)) == null) ] as $missing
+        | ( if ($schema.additionalProperties == false)
+            then [ $present[] | . as $p | select(($allowed | index($p)) == null) ]
+            else [] end )                        as $unknown
+        | if   ($missing | length) > 0 then
+            "Missing required parameter(s): " + ($missing | join(", ")) + "."
+          elif ($unknown | length) > 0 then
+            "Unknown parameter(s): " + ($unknown | join(", "))
+            + ". Allowed parameters: " + ($allowed | join(", ")) + "."
+          else "" end
+        ' 2>/dev/null || true)
+
+    if [[ -n "$message" ]]; then
+        printf '%s' "$message"
+        return 1
+    fi
+    return 0
+}
+
 handle_tools_call() {
     local id="$1"
     local params="$2"
@@ -135,6 +178,17 @@ handle_tools_call() {
     local func_name="tool_${tool_name}"
     if ! type "$func_name" &>/dev/null; then
         create_error_response "$id" -32601 "Tool not found: $tool_name"
+        return
+    fi
+
+    local validation_error
+    if ! validation_error=$(validate_tool_arguments "$tool_name" "$arguments"); then
+        log "ERROR" "Tool $tool_name argument validation failed: $validation_error"
+        local invalid_result
+        invalid_result=$(jq -n -c \
+            --arg text "$validation_error" \
+            '{"content": [{"type": "text", "text": $text}], "isError": true}')
+        create_response "$id" "$invalid_result"
         return
     fi
 

--- a/plugins/shopware-env/skills/dev-environment-bootstrapping/SKILL.md
+++ b/plugins/shopware-env/skills/dev-environment-bootstrapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-environment-bootstrapping
-version: 1.1.1
+version: 1.2.0
 model: sonnet
 description: Use this skill when the user asks to bootstrap, set up, create, or initialize a Shopware development environment from scratch — phrases like "set up a Shopware dev environment", "clone and install Shopware", "initialize a Shopware plugin project", "bootstrap Shopware and a new plugin called X", "get a fresh Shopware instance running". Orchestrates the full first-run flow — detects the current state of a Shopware checkout, proposes a numbered action plan, confirms with the user, then executes dependency installation, database setup, plugin activation, and frontend builds via the lifecycle-tooling MCP server. Hands off to dev-tooling setup when the environment is running.
 allowed-tools: AskUserQuestion, Bash, Read, Glob, Write, mcp__plugin_shopware-env_lifecycle-tooling__install_dependencies, mcp__plugin_shopware-env_lifecycle-tooling__database_install, mcp__plugin_shopware-env_lifecycle-tooling__database_reset, mcp__plugin_shopware-env_lifecycle-tooling__testdb_prepare, mcp__plugin_shopware-env_lifecycle-tooling__frontend_build_admin, mcp__plugin_shopware-env_lifecycle-tooling__frontend_build_storefront, mcp__plugin_shopware-env_lifecycle-tooling__plugin_create, mcp__plugin_shopware-env_lifecycle-tooling__plugin_setup

--- a/plugins/test-writing/.claude-plugin/plugin.json
+++ b/plugins/test-writing/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "test-writing",
-  "version": "3.8.18",
+  "version": "3.9.0",
   "description": "Generate and validate PHPUnit tests for Shopware 6. Unit tests: analyzes source classes to detect category (DTO, Service, Flow/Event, DAL, Exception) and applies category-specific templates. Migration tests: analyzes SQL operations to generate pattern-appropriate migration tests with 8 migration-specific rules. Integration tests: generates wired-up tests via phpunit-integration-test-generation for controller, message-handler, indexer, DAL-flow, and multi-service patterns (defers to unit generation when the SUT is unit-shape); 8 quality rules plus a placement smoke check via phpunit-integration-test-reviewing; a separate user-invoked phpunit-integration-to-unit-migrating skill audits placement with 8 deep-reasoning rules and migrates load-bearing-free tests to the unit suite. Workflow-based team review: wave-orchestrated agents coordinated through a shared blackboard (no agent-to-agent messaging), with adversarial red team and defense rounds. Bundles test-rules MCP server for Shopware compliance rules. Orchestrator runs inline fix loop (max 4 iterations) with oscillation detection. Optional dev-tooling plugin enables PHPStan/PHPUnit/ECS validation in the fix loop.",
   "author": {
     "name": "Shopware Labs"

--- a/plugins/test-writing/CHANGELOG.md
+++ b/plugins/test-writing/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.0] - 2026-06-25
+
+### Added
+- Tool-call arguments are now validated against the called tool's declared `inputSchema` before dispatch. Every field listed in `required` must be present, and when the schema sets `additionalProperties: false` any field outside `properties` is rejected — the call returns an `isError` result naming the missing or unknown parameters instead of running the tool. Applies to the bundled `test-rules` server; tools without a schema are left unvalidated. Added as `validate_tool_arguments` in the shared `mcpserver_core.sh`, which is now registered as a `templates/mcp-shared/` consumer and covered by the CI template-sync check.
+
 ## [3.8.18] - 2026-06-25
 
 ### Changed

--- a/plugins/test-writing/shared/mcpserver_core.sh
+++ b/plugins/test-writing/shared/mcpserver_core.sh
@@ -114,6 +114,49 @@ handle_tools_list() {
     create_response "$id" "$result"
 }
 
+# Validate call arguments against the tool's declared inputSchema.
+# Enforces `required` (every listed field must be present) and, when the schema
+# sets `additionalProperties: false`, rejects any field not in `properties`.
+# Tools without a schema (or with an unreadable tools list) are not validated.
+# Args: $1 = tool name, $2 = arguments JSON object
+# On violation: prints a human-readable message to stdout and returns 1.
+validate_tool_arguments() {
+    local tool_name="$1"
+    local arguments="$2"
+
+    local tools_config schema
+    tools_config=$(read_json_file "$MCP_TOOLS_LIST_FILE")
+    schema=$(echo "$tools_config" | jq -c --arg n "$tool_name" \
+        '(.tools[]? | select(.name == $n) | .inputSchema) // empty' 2>/dev/null || true)
+    [[ -z "$schema" || "$schema" == "null" ]] && return 0
+
+    local message
+    message=$(jq -n -r \
+        --argjson schema "$schema" \
+        --argjson args "$arguments" \
+        '
+        ($schema.required // [])               as $req
+        | ($args | keys)                        as $present
+        | (($schema.properties // {}) | keys)   as $allowed
+        | [ $req[]     | . as $r | select(($present | index($r)) == null) ] as $missing
+        | ( if ($schema.additionalProperties == false)
+            then [ $present[] | . as $p | select(($allowed | index($p)) == null) ]
+            else [] end )                        as $unknown
+        | if   ($missing | length) > 0 then
+            "Missing required parameter(s): " + ($missing | join(", ")) + "."
+          elif ($unknown | length) > 0 then
+            "Unknown parameter(s): " + ($unknown | join(", "))
+            + ". Allowed parameters: " + ($allowed | join(", ")) + "."
+          else "" end
+        ' 2>/dev/null || true)
+
+    if [[ -n "$message" ]]; then
+        printf '%s' "$message"
+        return 1
+    fi
+    return 0
+}
+
 handle_tools_call() {
     local id="$1"
     local params="$2"
@@ -135,6 +178,17 @@ handle_tools_call() {
     local func_name="tool_${tool_name}"
     if ! type "$func_name" &>/dev/null; then
         create_error_response "$id" -32601 "Tool not found: $tool_name"
+        return
+    fi
+
+    local validation_error
+    if ! validation_error=$(validate_tool_arguments "$tool_name" "$arguments"); then
+        log "ERROR" "Tool $tool_name argument validation failed: $validation_error"
+        local invalid_result
+        invalid_result=$(jq -n -c \
+            --arg text "$validation_error" \
+            '{"content": [{"type": "text", "text": $text}], "isError": true}')
+        create_response "$id" "$invalid_result"
         return
     fi
 

--- a/plugins/test-writing/skills/phpunit-integration-test-generation/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-integration-test-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-integration-test-generation
-version: 3.8.18
+version: 3.9.0
 description: Use this skill when the user asks to generate, write, or create integration tests for a Shopware 6 source class whose contract requires wired-up code — phrases like "generate integration tests for X", "write an integration test for this controller", "test this indexer", "create an integration test for the message handler". Detects supported integration patterns (controller/route, scheduled-task, message-handler, indexer, DAL-persistence flow, multi-service coordinator) and applies a template producing an INTEGRATION-001..008-compliant test using IntegrationTestBehaviour against the real DAL, container, and HTTP/messaging. When the source class is unit-shape (no persistence, no kernel state, no wiring under test), returns SKIPPED and points at phpunit-unit-test-writing. Do NOT activate for unit tests or migration tests (use phpunit-migration-test-generation).
 user-invocable: true
 context: fork

--- a/plugins/test-writing/skills/phpunit-integration-test-reviewing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-integration-test-reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-integration-test-reviewing
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-integration-to-unit-migrating/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-integration-to-unit-migrating/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-integration-to-unit-migrating
-version: 3.8.18
+version: 3.9.0
 description: Use this skill ONLY when the user explicitly requests an audit, migration, or evaluation of whether a Shopware integration test belongs in the unit suite — trigger phrases like "audit integration tests", "migrate integration tests to unit", "is this an integration test or a unit test", "evaluate integration tests for migration", "should this be a unit test instead". Audits tests under tests/integration/ for misplacement and migrates load-bearing-free tests to tests/unit/ using one of six codified refactoring patterns. NOT invoked automatically by reviewing skills — phpunit-integration-test-reviewing emits a placement smoke-alarm hint pointing here, but the user must invoke this skill explicitly to run the deep audit.
 user-invocable: true
 allowed-tools: Glob, Grep, Read, Edit, Write, AskUserQuestion, Bash, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-migration-test-generation/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-migration-test-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-migration-test-generation
-version: 3.8.18
+version: 3.9.0
 description: Use this skill when the user asks to generate, write, or create migration tests for a Shopware 6 migration class — phrases like "generate migration tests", "write a migration test", "create migration test", "test this migration", "test Migration1234Foo". Analyzes the source migration's SQL operations to pick an appropriate pattern (schema-add, schema-remove, data-update, config, mail template), then generates a test that runs against a real database and passes PHPStan and PHPUnit validation. Do NOT activate for unit tests (use phpunit-unit-test-writing) or integration tests of non-migration source classes (use phpunit-integration-test-generation).
 user-invocable: true
 context: fork

--- a/plugins/test-writing/skills/phpunit-migration-test-reviewing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-migration-test-reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-migration-test-reviewing
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-unit-test-adversarial-reviewing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-adversarial-reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-adversarial-reviewing
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-unit-test-generation/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-generation
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 context: fork

--- a/plugins/test-writing/skills/phpunit-unit-test-reconciling/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-reconciling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-reconciling
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 allowed-tools: Read, Glob, Grep, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-unit-test-reviewing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-reviewing
-version: 3.8.18
+version: 3.9.0
 description: Internal sub-skill. Do not auto-activate. Use only when explicitly invoked by name by another skill or agent.
 user-invocable: false
 allowed-tools: Glob, Grep, Read, mcp__plugin_test-writing_test-rules__get_rules

--- a/plugins/test-writing/skills/phpunit-unit-test-team-reviewing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-team-reviewing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-team-reviewing
-version: 3.8.18
+version: 3.9.0
 description: Use this skill when the user asks for a team-based, consensus, multi-reviewer, or red-team review of Shopware PHPUnit unit tests (in tests/unit/) — trigger phrases like "team review these unit tests", "consensus review the unit tests in PR #N", "red-team this unit test suite", "multi-reviewer audit of tests/unit/...". Accepts file paths, directories, commits, branches, and PRs as input. Unit tests only — not for integration tests in tests/integration/. For a single-reviewer pass, use phpunit-unit-test-writing instead.
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, Workflow, mcp__plugin_gh-tooling_gh-tooling, mcp__plugin_test-writing_test-rules__build_rule_package
 ---

--- a/plugins/test-writing/skills/phpunit-unit-test-writing/SKILL.md
+++ b/plugins/test-writing/skills/phpunit-unit-test-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phpunit-unit-test-writing
-version: 3.8.18
+version: 3.9.0
 description: Use this skill when the user asks to write, generate, create, or add PHPUnit unit tests for a Shopware 6 source class — phrases like "write unit tests for X", "generate tests for ClassName", "create PHPUnit tests", "add test coverage", "test this class", "cover this with tests", "I need tests for", "unit test this", "SW6 unit tests", "Shopware unit tests", "PHPUnit tests for Shopware". Orchestrates the full workflow — source-class category detection (DTO, Service, Flow/Event, DAL, Exception), test generation, MCP-driven review against Shopware unit-test rules, and an inline fix loop that iterates until tests pass. Do NOT activate for integration tests (use phpunit-integration-test-generation), migration tests (use phpunit-migration-test-generation), e2e tests, or non-PHP testing.
 allowed-tools: Skill, Edit, Read, Glob, TodoWrite, AskUserQuestion, mcp__plugin_dev-tooling_php-tooling
 ---

--- a/templates/mcp-shared/mcpserver_core.sh
+++ b/templates/mcp-shared/mcpserver_core.sh
@@ -114,6 +114,49 @@ handle_tools_list() {
     create_response "$id" "$result"
 }
 
+# Validate call arguments against the tool's declared inputSchema.
+# Enforces `required` (every listed field must be present) and, when the schema
+# sets `additionalProperties: false`, rejects any field not in `properties`.
+# Tools without a schema (or with an unreadable tools list) are not validated.
+# Args: $1 = tool name, $2 = arguments JSON object
+# On violation: prints a human-readable message to stdout and returns 1.
+validate_tool_arguments() {
+    local tool_name="$1"
+    local arguments="$2"
+
+    local tools_config schema
+    tools_config=$(read_json_file "$MCP_TOOLS_LIST_FILE")
+    schema=$(echo "$tools_config" | jq -c --arg n "$tool_name" \
+        '(.tools[]? | select(.name == $n) | .inputSchema) // empty' 2>/dev/null || true)
+    [[ -z "$schema" || "$schema" == "null" ]] && return 0
+
+    local message
+    message=$(jq -n -r \
+        --argjson schema "$schema" \
+        --argjson args "$arguments" \
+        '
+        ($schema.required // [])               as $req
+        | ($args | keys)                        as $present
+        | (($schema.properties // {}) | keys)   as $allowed
+        | [ $req[]     | . as $r | select(($present | index($r)) == null) ] as $missing
+        | ( if ($schema.additionalProperties == false)
+            then [ $present[] | . as $p | select(($allowed | index($p)) == null) ]
+            else [] end )                        as $unknown
+        | if   ($missing | length) > 0 then
+            "Missing required parameter(s): " + ($missing | join(", ")) + "."
+          elif ($unknown | length) > 0 then
+            "Unknown parameter(s): " + ($unknown | join(", "))
+            + ". Allowed parameters: " + ($allowed | join(", ")) + "."
+          else "" end
+        ' 2>/dev/null || true)
+
+    if [[ -n "$message" ]]; then
+        printf '%s' "$message"
+        return 1
+    fi
+    return 0
+}
+
 handle_tools_call() {
     local id="$1"
     local params="$2"
@@ -135,6 +178,17 @@ handle_tools_call() {
     local func_name="tool_${tool_name}"
     if ! type "$func_name" &>/dev/null; then
         create_error_response "$id" -32601 "Tool not found: $tool_name"
+        return
+    fi
+
+    local validation_error
+    if ! validation_error=$(validate_tool_arguments "$tool_name" "$arguments"); then
+        log "ERROR" "Tool $tool_name argument validation failed: $validation_error"
+        local invalid_result
+        invalid_result=$(jq -n -c \
+            --arg text "$validation_error" \
+            '{"content": [{"type": "text", "text": $text}], "isError": true}')
+        create_response "$id" "$invalid_result"
         return
     fi
 


### PR DESCRIPTION
The bash MCP servers across this marketplace dispatched every tool call straight to its handler without checking the arguments against the tool's declared `inputSchema`. A missing required field or a misspelled parameter reached the handler and failed with an opaque downstream error, or got silently dropped. gh-tooling 3.3.0 patched one symptom of that by hand, where a `number` passed under a wrong key resolved a different PR instead of failing. The fix here is structural. A new `validate_tool_arguments` in the shared `mcpserver_core.sh` rejects schema-violating calls before dispatch and returns an error that names the offending parameter, so the failure is immediate and legible instead of buried downstream.

### How the validator works

`handle_tools_call` runs `validate_tool_arguments` before it dispatches. Every field in the schema's `required` array must be present, and when the schema declares `additionalProperties: false` any field outside `properties` is rejected. A violation returns a tool result with `isError: true` and a message listing the missing or unknown parameters, so the model sees the correction directly. Tools that ship no `inputSchema` are left unvalidated, which keeps the change inert for any handler that hasn't declared a contract.

### Rollout across the bash-MCP plugins

`mcpserver_core.sh` is a template. The source of truth lives at `templates/mcp-shared/mcpserver_core.sh` and is copied byte-identical into each plugin that runs a bash MCP server. All four consumers get the validator:

| Plugin         | MCP server(s)                                          | Version |
|----------------|-------------------------------------------------------|---------|
| `dev-tooling`  | `php-tooling`, `js-admin-tooling`, `js-storefront-tooling` | 3.14.0  |
| `gh-tooling`   | `gh-tooling`, `gh-tooling-write`                       | 3.4.0   |
| `shopware-env` | `lifecycle-tooling`                                   | 1.2.0   |
| `test-writing` | `test-rules`                                          | 3.9.0   |

`test-writing` was the one consumer the first commit missed, even though its `test-rules` server sources the same file. `gh-tooling` and `test-writing` are now both registered in `template-sync.md` and in the authoritative CI check (`validate.yml`), so all four copies are verified identical to the template on every run. The bumps are minor because each server now rejects calls it used to accept, a runtime behavior change rather than a pure internal fix.

### Central test suite

The validator's bats suite moved from `plugin-tests/gh-tooling/` to `plugin-tests/mcp-shared/` and sources the template directly. Because template-sync keeps every plugin copy byte-identical, one suite covers the validator in all four servers instead of testing it through a single plugin's copy. The directory mirrors `templates/mcp-shared/`, where the code under test lives.

## References

Follows #131
