### PR TITLE
feat(shopware-documentation): add structuring-documentation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,8 @@
     { "name": "contributor-writing", "source": "./plugins/contributor-writing" },
     { "name": "code-contribution-analysis", "source": "./plugins/code-contribution-analysis" },
     { "name": "shopware-env", "source": "./plugins/shopware-env" },
-    { "name": "plugin-setup", "source": "./plugins/plugin-setup" }
+    { "name": "plugin-setup", "source": "./plugins/plugin-setup" },
+    { "name": "shopware-documentation", "source": "./plugins/shopware-documentation" }
   ],
   "renames": {
     "gh-tooling": null

--- a/.github/ISSUE_TEMPLATE/plugin_component_other.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_component_other.yml
@@ -39,6 +39,7 @@ body:
         - contributor-writing
         - dev-tooling
         - plugin-setup
+        - shopware-documentation
         - shopware-env
         - test-writing
         - Other

--- a/.github/ISSUE_TEMPLATE/skill_issue.yml
+++ b/.github/ISSUE_TEMPLATE/skill_issue.yml
@@ -42,6 +42,7 @@ body:
         - contributor-writing / release-info-writing
         - plugin-setup / chunkhound-integration-setting-up
         - plugin-setup / dev-tooling-setting-up
+        - shopware-documentation / structuring-documentation
         - shopware-env / dev-environment-bootstrapping
         - test-writing / phpunit-integration-test-generation
         - test-writing / phpunit-integration-test-reviewing

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These plugins work best alongside a few Claude Code tweaks. Turn on `ENABLE_TOOL
 | [code-contribution-analysis](#code-contribution-analysis) | Analyzes GitHub pull requests and issues in depth. Two skills fetch contribution data and research architectural context via ChunkHound. | 🎯 Skills                                           |
 | [shopware-env](#shopware-env)                             | Bootstrap and maintain Shopware development environments. Dependencies, database, frontend builds, plugin management.                    | 🔌 MCP · 🪝 Hooks · 🎯 Skills                       |
 | [plugin-setup](#plugin-setup)                             | Interactive setup skills for dev-tooling and chunkhound-integration. Install alongside a plugin, run setup, uninstall.                   | 🎯 Skills                                           |
+| [shopware-documentation](#shopware-documentation)         | Documentation-surface structuring: size budgets, one subject per file, splitting, and cross-reference integrity, via measurement script. | 🎯 Skills                                           |
 
 ### dev-tooling
 
@@ -196,6 +197,25 @@ Help me set up chunkhound-integration
 No prerequisites. Skills are self-contained and uninstallable once you are done.
 
 See [full documentation](./plugins/plugin-setup/README.md) for details.
+
+### shopware-documentation
+
+Structuring skill for Markdown documentation surfaces: size budgets per file, one subject per surface, splitting oversized surfaces into `docs/` siblings, and cross-reference integrity. Ships a measurement script that reports counted characters and resolves every relative Markdown cross-reference (web and mail links [http, https, mailto] and non-`.md` targets are skipped by design).
+
+```bash
+/plugin install shopware-documentation@shopware-ai-coding-tools
+```
+
+```
+Is this README too long?
+Measure the docs under src/Core/Framework/ContentSystem
+Split this README into docs/ siblings
+Where does this documentation belong?
+```
+
+The `structuring-documentation` skill activates automatically. No prerequisites beyond installation.
+
+See [full documentation](./plugins/shopware-documentation/README.md) for the script modes, budget flags, and scope rules.
 
 ## 📦 Agent Skills Export
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Split this README into docs/ siblings
 Where does this documentation belong?
 ```
 
-The `structuring-documentation` skill activates automatically. No prerequisites beyond installation.
+The `structuring-documentation` skill activates automatically. Prerequisites: a Unix-like host (bash and POSIX utilities; present on macOS and Linux). No other plugins required.
 
 See [full documentation](./plugins/shopware-documentation/README.md) for the script modes, budget flags, and scope rules.
 

--- a/plugin-tests/shopware-documentation/fixtures/links/absolute/target.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/absolute/target.md
@@ -1,0 +1,3 @@
+# Absolute Target
+
+The surface the absolute-looking link concatenation test resolves to.

--- a/plugin-tests/shopware-documentation/fixtures/links/absolute_target.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/absolute_target.md
@@ -1,0 +1,3 @@
+# Citing
+
+See [target](/absolute/target.md) here.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_backticks_punctuation.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_backticks_punctuation.md
@@ -1,0 +1,3 @@
+# Anchor Backticks Punctuation
+
+See [fetch behavior](anchor_target_backticks.md#getdata-fetch-now) for details.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_fenced_heading.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_fenced_heading.md
@@ -1,0 +1,3 @@
+# Anchor Fenced Heading
+
+See [the fenced heading](anchor_target_fenced_heading.md#fenced-heading) for details.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_found.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_found.md
@@ -1,0 +1,3 @@
+# Anchor Found
+
+See [usage notes](target.md#usage-notes) for the reading order.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_heading_trailing_space.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_heading_trailing_space.md
@@ -1,0 +1,3 @@
+# Anchor Heading Trailing Space
+
+See [the setup section](anchor_target_heading_trailing_space.md#setup) for details.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_missing.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_missing.md
@@ -1,0 +1,3 @@
+# Anchor Missing
+
+See [installation steps](target.md#installation-steps) for the setup.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_restates.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_restates.md
@@ -1,0 +1,3 @@
+# Anchor Restates
+
+See [product catalog](product-catalog.md#product-catalog) for the catalog.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_target_backticks.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_target_backticks.md
@@ -1,0 +1,5 @@
+# Anchor Target Backticks
+
+## `getData()`: Fetch Now!
+
+Explains the method.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_target_fenced_heading.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_target_fenced_heading.md
@@ -1,0 +1,5 @@
+# Anchor Target Fenced Heading
+
+```markdown
+## Fenced Heading
+```

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_target_heading_trailing_space.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_target_heading_trailing_space.md
@@ -1,0 +1,5 @@
+# Anchor Target Heading Trailing Space
+
+## Setup ##   
+
+Explains a heading whose ATX closer is followed by trailing whitespace.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_target_trailing_hash.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_target_trailing_hash.md
@@ -1,0 +1,5 @@
+# Anchor Target Trailing Hash
+
+## Trailing Marker ##
+
+Explains a heading whose ATX closer uses trailing hashes.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_target_unicode_heading.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_target_unicode_heading.md
@@ -1,0 +1,3 @@
+## Ünïcode heading
+
+Body text.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_trailing_hash.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_trailing_hash.md
@@ -1,0 +1,3 @@
+# Anchor Trailing Hash
+
+See [the marker section](anchor_target_trailing_hash.md#trailing-marker) for details.

--- a/plugin-tests/shopware-documentation/fixtures/links/anchor_unicode_heading.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/anchor_unicode_heading.md
@@ -1,0 +1,3 @@
+# Citing surface
+
+[Guide](anchor_target_unicode_heading.md#ncode-heading)

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_fenced.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_fenced.md
@@ -1,0 +1,9 @@
+# Bare Path Fenced
+
+The sample below shows a bare reference inside a fence, not a real one:
+
+```text
+See retired-guide.md, written here as `retired-guide.md`, for context.
+```
+
+See [product overview](target.md) for the one real citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_in_label.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_in_label.md
@@ -1,0 +1,3 @@
+# Bare Path In Label
+
+See [`target.md`](target.md) for the overview.

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_missing.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_missing.md
@@ -1,0 +1,5 @@
+# Bare Path Missing
+
+The retired guide lived in `no-such-guide.md` before it was removed.
+
+See [product catalog](product-catalog.md) for the one real citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_no_citation.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_no_citation.md
@@ -1,0 +1,3 @@
+# Bare Path No Citation
+
+This surface names `no-such-guide.md` in prose, never as a Markdown link.

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_placeholders.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_placeholders.md
@@ -1,0 +1,8 @@
+# Bare Path Placeholders
+
+Angle placeholder `<module>.md` names a slot, not a file.
+Glob placeholder `*.md` names a set, not a file.
+Brace placeholder `{module}.md` names a slot, not a file.
+Spaced placeholder `two words.md` names a slot, not a file.
+
+See [product catalog](product-catalog.md) for the one real citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/bare_path_resolves.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/bare_path_resolves.md
@@ -1,0 +1,5 @@
+# Bare Path Resolves
+
+The overview lives in `target.md` and is named there instead of cited.
+
+See [product catalog](product-catalog.md) for the one real citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/empty_target_no_anchor.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/empty_target_no_anchor.md
@@ -1,0 +1,3 @@
+# Empty Target No Anchor
+
+See [this very surface]() for self-reference.

--- a/plugin-tests/shopware-documentation/fixtures/links/fenced_links.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/fenced_links.md
@@ -1,0 +1,9 @@
+# Fenced Links
+
+The sample below shows the markup, it is not a real cross-reference:
+
+```markdown
+See [absent guide](no-such-guide.md) for the missing surface.
+```
+
+See [product overview](target.md) for the one real citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/indented_fence.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/indented_fence.md
@@ -1,0 +1,7 @@
+# Indented fence
+
+[Real](target.md)
+
+  ```
+  [Fake](target.md)
+  ```

--- a/plugin-tests/shopware-documentation/fixtures/links/missing_target.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/missing_target.md
@@ -1,0 +1,5 @@
+# Missing Target
+
+An intro paragraph that carries no citation at all.
+
+See [absent guide](no-such-guide.md) for the missing surface.

--- a/plugin-tests/shopware-documentation/fixtures/links/missing_target_with_anchor.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/missing_target_with_anchor.md
@@ -1,0 +1,3 @@
+# Missing Target With Anchor
+
+See [absent guide](no-such-guide.md#some-anchor) for the missing surface.

--- a/plugin-tests/shopware-documentation/fixtures/links/multiple_links.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/multiple_links.md
@@ -1,0 +1,3 @@
+# Multiple Links
+
+Read [product overview](target.md) and [product catalog](product-catalog.md) together.

--- a/plugin-tests/shopware-documentation/fixtures/links/no_citation.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/no_citation.md
@@ -1,0 +1,3 @@
+# No Citation
+
+This surface names no other surface anywhere in its prose.

--- a/plugin-tests/shopware-documentation/fixtures/links/non_md_target.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/non_md_target.md
@@ -1,0 +1,5 @@
+# Non Markdown Target
+
+Download the [changelog archive](changelog.txt) before upgrading.
+
+See [product overview](target.md) for the one internal citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/product-catalog.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/product-catalog.md
@@ -1,0 +1,3 @@
+# Product Catalog
+
+The catalog surface whose filename stem matches its own heading slug.

--- a/plugin-tests/shopware-documentation/fixtures/links/resolving_link.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/resolving_link.md
@@ -1,0 +1,3 @@
+# Resolving Link
+
+See [product overview](target.md) for the shape of the surface.

--- a/plugin-tests/shopware-documentation/fixtures/links/same_file_anchor.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/same_file_anchor.md
@@ -1,0 +1,7 @@
+# Same File Anchor
+
+Jump to [usage](#usage) further down this surface.
+
+## Usage
+
+The section the same-file anchor points at.

--- a/plugin-tests/shopware-documentation/fixtures/links/skipped_schemes.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/skipped_schemes.md
@@ -1,0 +1,7 @@
+# Skipped Schemes
+
+The [external handbook](https://example.com/handbook.md) lives off-site.
+The [legacy manual](http://example.com/legacy.md) lives off-site too.
+Reach [the docs team](mailto:docs@example.com) for anything else.
+
+See [product overview](target.md) for the one internal citation.

--- a/plugin-tests/shopware-documentation/fixtures/links/target.md
+++ b/plugin-tests/shopware-documentation/fixtures/links/target.md
@@ -1,0 +1,7 @@
+# Product Overview
+
+The overview surface other fixtures cite.
+
+## Usage Notes
+
+How the overview is meant to be read.

--- a/plugin-tests/shopware-documentation/fixtures/rows/all_markers.md
+++ b/plugin-tests/shopware-documentation/fixtures/rows/all_markers.md
@@ -1,0 +1,7 @@
+# Marker Forms
+
+- [dash row](target.md)
+* [star row](target.md)
++ [plus row](target.md)
+1. [ordered row](target.md)
+| [table row](target.md) | routing |

--- a/plugin-tests/shopware-documentation/fixtures/rows/fenced_row.md
+++ b/plugin-tests/shopware-documentation/fixtures/rows/fenced_row.md
@@ -1,0 +1,5 @@
+# Fenced Row
+
+```markdown
+- [product overview](target.md)
+```

--- a/plugin-tests/shopware-documentation/fixtures/rows/non_md_link.md
+++ b/plugin-tests/shopware-documentation/fixtures/rows/non_md_link.md
@@ -1,0 +1,3 @@
+# Non Markdown Link
+
+- [changelog archive](changelog.txt) holds the history.

--- a/plugin-tests/shopware-documentation/fixtures/rows/plain_paragraph.md
+++ b/plugin-tests/shopware-documentation/fixtures/rows/plain_paragraph.md
@@ -1,0 +1,3 @@
+# Plain Paragraph
+
+The [product overview](target.md) is cited from running prose here.

--- a/plugin-tests/shopware-documentation/fixtures/rows/two_sentences.md
+++ b/plugin-tests/shopware-documentation/fixtures/rows/two_sentences.md
@@ -1,0 +1,3 @@
+# Two Sentences
+
+- [product overview](target.md) explains the model. It also lists every field.

--- a/plugin-tests/shopware-documentation/fixtures/scope/alpha.md
+++ b/plugin-tests/shopware-documentation/fixtures/scope/alpha.md
@@ -1,0 +1,3 @@
+# Alpha Surface
+
+See [absent alpha](no-such-alpha.md) for the missing surface.

--- a/plugin-tests/shopware-documentation/fixtures/scope/nested/beta.md
+++ b/plugin-tests/shopware-documentation/fixtures/scope/nested/beta.md
@@ -1,0 +1,3 @@
+# Beta Surface
+
+See [absent beta](no-such-beta.md) for the missing surface.

--- a/plugin-tests/shopware-documentation/fixtures/scope/notes.txt
+++ b/plugin-tests/shopware-documentation/fixtures/scope/notes.txt
@@ -1,0 +1,1 @@
+Plain-text notes that carry no markdown suffix.

--- a/plugin-tests/shopware-documentation/fixtures/scope/zulu.md
+++ b/plugin-tests/shopware-documentation/fixtures/scope/zulu.md
@@ -1,0 +1,3 @@
+# Zulu Surface
+
+See [absent zulu](no-such-zulu.md) for the missing surface.

--- a/plugin-tests/shopware-documentation/measure_cli.bats
+++ b/plugin-tests/shopware-documentation/measure_cli.bats
@@ -46,6 +46,16 @@ load 'test_helper/common_setup'
     assert_output --partial '2 surfaces measured, 0 findings'
 }
 
+@test "-- ends flag parsing so a dash-prefixed path is measured, not rejected as a flag" {
+    cd "${BATS_TEST_TMPDIR}" || fail "could not enter ${BATS_TEST_TMPDIR}"
+    make_counted_md '-dashed.md' 5000
+
+    run_measure size -- '-dashed.md'
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
 @test "a nonexistent path is rejected by name" {
     run_measure size "${BATS_TEST_TMPDIR}/absent-surface.md"
 

--- a/plugin-tests/shopware-documentation/measure_cli.bats
+++ b/plugin-tests/shopware-documentation/measure_cli.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+# bats file_tags=shopware-documentation,measure-cli
+# Command-line surface of measure.sh: argument handling, scope expansion,
+# the composed `all` mode, and the exit-code contract.
+bats_require_minimum_version 1.11.0
+
+load 'test_helper/common_setup'
+
+# --- argument handling ---
+
+@test "an invocation with no path prints usage" {
+    run_measure size
+
+    assert_failure 2
+    assert_stderr_contains 'measure.sh <mode> [flags] PATH'
+}
+
+@test "an unrecognised mode prints usage" {
+    run_measure sizes "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_failure 2
+    assert_stderr_contains 'measure.sh <mode> [flags] PATH'
+}
+
+@test "an unrecognised flag prints usage" {
+    run_measure size --verbose "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_failure 2
+    assert_stderr_contains 'measure.sh <mode> [flags] PATH'
+}
+
+@test "a non-numeric budget value prints usage" {
+    run_measure size --goal generous "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_failure 2
+    assert_stderr_contains 'measure.sh <mode> [flags] PATH'
+}
+
+@test "flags interleaved between paths are still parsed" {
+    make_counted_md "${BATS_TEST_TMPDIR}/a.md" 7000
+    make_counted_md "${BATS_TEST_TMPDIR}/b.md" 7000
+
+    run_measure size "${BATS_TEST_TMPDIR}/a.md" --goal 8000 "${BATS_TEST_TMPDIR}/b.md"
+
+    assert_success
+    assert_output --partial '2 surfaces measured, 0 findings'
+}
+
+@test "a nonexistent path is rejected by name" {
+    run_measure size "${BATS_TEST_TMPDIR}/absent-surface.md"
+
+    assert_failure 2
+    assert_stderr_contains "path does not exist: ${BATS_TEST_TMPDIR}/absent-surface.md"
+}
+
+@test "several nonexistent paths are reported in one comma-joined line" {
+    run_measure size "${BATS_TEST_TMPDIR}/absent-one.md" "${BATS_TEST_TMPDIR}/absent-two.md"
+
+    assert_failure 2
+    assert_stderr_contains "path does not exist: ${BATS_TEST_TMPDIR}/absent-one.md, ${BATS_TEST_TMPDIR}/absent-two.md"
+}
+
+@test "one nonexistent path among existing ones measures nothing and names only the missing path" {
+    run_measure size "${FIXTURES_DIR}/links/resolving_link.md" "${BATS_TEST_TMPDIR}/absent-surface.md"
+
+    assert_failure 2
+    assert_output ''
+    assert_stderr_contains "path does not exist: ${BATS_TEST_TMPDIR}/absent-surface.md"
+}
+
+# --- scope expansion ---
+
+@test "a directory scope measures only its markdown files" {
+    run_measure size "${FIXTURES_DIR}/scope"
+
+    assert_success
+    assert_output --partial '3 surfaces measured, 0 findings'
+}
+
+@test "a directory scope reports its files sorted by full path" {
+    run_measure links "${FIXTURES_DIR}/scope"
+
+    assert_success
+    assert_line --index 1 --partial 'alpha.md'
+    assert_line --index 2 --partial 'nested/beta.md'
+    assert_line --index 3 --partial 'zulu.md'
+}
+
+@test "two directory paths given in reverse lexicographic order are reported per-directory sorted, not globally merged" {
+    mkdir -p "${BATS_TEST_TMPDIR}/zzz" "${BATS_TEST_TMPDIR}/aaa"
+    printf '%s\n' '# Z A' '' 'See [missing](no-such.md) here.' > "${BATS_TEST_TMPDIR}/zzz/a.md"
+    printf '%s\n' '# Z B' '' 'See [missing](no-such.md) here.' > "${BATS_TEST_TMPDIR}/zzz/b.md"
+    printf '%s\n' '# A X' '' 'See [missing](no-such.md) here.' > "${BATS_TEST_TMPDIR}/aaa/x.md"
+    printf '%s\n' '# A Y' '' 'See [missing](no-such.md) here.' > "${BATS_TEST_TMPDIR}/aaa/y.md"
+
+    run_measure links "${BATS_TEST_TMPDIR}/zzz" "${BATS_TEST_TMPDIR}/aaa"
+
+    assert_success
+    assert_line --index 1 --partial 'zzz/a.md'
+    assert_line --index 2 --partial 'zzz/b.md'
+    assert_line --index 3 --partial 'aaa/x.md'
+    assert_line --index 4 --partial 'aaa/y.md'
+}
+
+@test "an existing file without the markdown suffix contributes no surface" {
+    run_measure size "${FIXTURES_DIR}/scope/notes.txt"
+
+    assert_success
+    assert_output --partial '0 surfaces measured, 0 findings'
+}
+
+# --- all mode ---
+
+@test "all mode prints the links report one blank line after the size report" {
+    run_measure all "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_success
+    assert_line --index 3 '1 surface measured, 0 findings'
+    assert_line --index 4 ''
+    assert_line --index 5 '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a finding from the size half drives the strict exit code in all mode" {
+    make_counted_md "${BATS_TEST_TMPDIR}/oversized.md" 10001 \
+        '## Usage' '' 'Jump to [usage](#usage) for the details.'
+
+    run_measure all --strict "${BATS_TEST_TMPDIR}/oversized.md"
+
+    assert_failure 1
+    assert_output --partial '10001 chars above the 10000 ceiling'
+}
+
+@test "a raised goal in all mode shifts the size verdict while the links half stays unaffected" {
+    printf '# Target\n' > "${BATS_TEST_TMPDIR}/target.md"
+    make_counted_md "${BATS_TEST_TMPDIR}/surface.md" 7000 \
+        '## Heading' '' 'See [Guide](target.md) for more.'
+
+    run_measure all --goal 8000 "${BATS_TEST_TMPDIR}/surface.md"
+
+    assert_success
+    assert_output --partial '    0  goal'
+    assert_output --partial '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a finding from the links half drives the strict exit code in all mode" {
+    run_measure all --strict "${FIXTURES_DIR}/links/missing_target.md"
+
+    assert_failure 1
+    assert_output --partial 'link target does not exist: no-such-guide.md'
+}
+
+# --- exit codes ---
+
+@test "findings without strict mode still exit zero" {
+    make_counted_md "${BATS_TEST_TMPDIR}/oversized.md" 10001
+
+    run_measure size "${BATS_TEST_TMPDIR}/oversized.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 1 findings'
+}
+
+@test "findings under strict mode exit one" {
+    make_counted_md "${BATS_TEST_TMPDIR}/oversized.md" 10001
+
+    run_measure size --strict "${BATS_TEST_TMPDIR}/oversized.md"
+
+    assert_failure 1
+    assert_output --partial '1 surface measured, 1 findings'
+}
+
+@test "a clean run under strict mode exits zero" {
+    make_counted_md "${BATS_TEST_TMPDIR}/within-goal.md" 5000
+
+    run_measure size --strict "${BATS_TEST_TMPDIR}/within-goal.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}

--- a/plugin-tests/shopware-documentation/measure_links.bats
+++ b/plugin-tests/shopware-documentation/measure_links.bats
@@ -166,6 +166,7 @@ load 'test_helper/common_setup'
     run_measure links "${FIXTURES_DIR}/links/bare_path_resolves.md"
 
     assert_success
+    # shellcheck disable=SC2016  # asserts literal output containing backticks
     assert_output --partial 'bare path is not a cross-reference (resolves): `target.md`'
 }
 
@@ -173,6 +174,7 @@ load 'test_helper/common_setup'
     run_measure links "${FIXTURES_DIR}/links/bare_path_missing.md"
 
     assert_success
+    # shellcheck disable=SC2016  # asserts literal output containing backticks
     assert_output --partial 'bare path is not a cross-reference (DOES NOT RESOLVE): `no-such-guide.md`'
 }
 

--- a/plugin-tests/shopware-documentation/measure_links.bats
+++ b/plugin-tests/shopware-documentation/measure_links.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# bats file_tags=shopware-documentation,measure-links
+# `links` mode: citation resolution, anchor checks, backticked bare paths, and
+# the known-positive fixture guard.
+bats_require_minimum_version 1.11.0
+
+load 'test_helper/common_setup'
+
+# --- markdown link resolution ---
+
+@test "a relative link to an existing surface counts as resolved" {
+    run_measure links "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_success
+    assert_line --index 0 '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a link to a missing surface is a finding on its 1-based line" {
+    cd "${FIXTURES_DIR}/links" || fail "could not enter the links fixture directory"
+
+    run_measure links 'missing_target.md'
+
+    assert_success
+    assert_line --index 1 '  missing_target.md:5: link target does not exist: no-such-guide.md'
+}
+
+@test "every link on a single line is scanned" {
+    run_measure links "${FIXTURES_DIR}/links/multiple_links.md"
+
+    assert_success
+    assert_output --partial '2 citations found, 2 resolved, 0 findings'
+}
+
+@test "the links summary line reports exact counts for a multi-citation scope" {
+    run_measure links "${FIXTURES_DIR}/links/multiple_links.md"
+
+    assert_success
+    assert_line --index 0 '1 files scanned, 2 citations found, 2 resolved, 0 findings'
+}
+
+@test "a link with an empty target and no anchor resolves against the citing surface" {
+    run_measure links "${FIXTURES_DIR}/links/empty_target_no_anchor.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "links inside a fence are not scanned" {
+    run_measure links "${FIXTURES_DIR}/links/fenced_links.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a fence delimiter with leading whitespace still hides the link inside it" {
+    run_measure links "${FIXTURES_DIR}/links/indented_fence.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "an absolute-looking link target is resolved by concatenation with the citing directory" {
+    run_measure links "${FIXTURES_DIR}/links/absolute_target.md"
+
+    assert_success
+    assert_line --index 0 '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+# --- anchors ---
+
+@test "an anchor present in the target resolves cleanly" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_found.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "an anchor absent from the target is a finding" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_missing.md"
+
+    assert_success
+    assert_output --partial 'anchor not found in target.md: #installation-steps'
+}
+
+@test "an anchor that restates the target filename is a finding" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_restates.md"
+
+    assert_success
+    assert_output --partial 'anchor restates the target file: #product-catalog'
+}
+
+@test "an anchor with an empty target resolves against the citing surface" {
+    run_measure links "${FIXTURES_DIR}/links/same_file_anchor.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a missing target with an anchor reports only the missing-target finding" {
+    cd "${FIXTURES_DIR}/links" || fail "could not enter the links fixture directory"
+
+    run_measure links 'missing_target_with_anchor.md'
+
+    assert_success
+    assert_line --index 0 '1 files scanned, 1 citations found, 0 resolved, 1 findings'
+    assert_line --index 1 '  missing_target_with_anchor.md:3: link target does not exist: no-such-guide.md'
+}
+
+# --- anchor slug edge cases ---
+
+@test "a heading with backticks and punctuation resolves via its computed slug" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_backticks_punctuation.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a heading with a trailing ATX closer resolves via its stripped slug" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_trailing_hash.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a heading inside a fence does not contribute an anchor" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_fenced_heading.md"
+
+    assert_success
+    assert_output --partial 'anchor not found in anchor_target_fenced_heading.md: #fenced-heading'
+}
+
+@test "non-ASCII characters in a heading are deleted from its slug" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_unicode_heading.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+# --- skipped link targets ---
+
+@test "web and mail links are not citations" {
+    run_measure links "${FIXTURES_DIR}/links/skipped_schemes.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a link to a non-markdown target is not a citation" {
+    run_measure links "${FIXTURES_DIR}/links/non_md_target.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+# --- backticked bare paths ---
+
+@test "a backticked markdown path that resolves is a finding" {
+    run_measure links "${FIXTURES_DIR}/links/bare_path_resolves.md"
+
+    assert_success
+    assert_output --partial 'bare path is not a cross-reference (resolves): `target.md`'
+}
+
+@test "a backticked markdown path that does not resolve is a finding" {
+    run_measure links "${FIXTURES_DIR}/links/bare_path_missing.md"
+
+    assert_success
+    assert_output --partial 'bare path is not a cross-reference (DOES NOT RESOLVE): `no-such-guide.md`'
+}
+
+@test "backticked placeholder spans are not reported as bare paths" {
+    run_measure links "${FIXTURES_DIR}/links/bare_path_placeholders.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a backticked path inside a link label is not reported separately" {
+    run_measure links "${FIXTURES_DIR}/links/bare_path_in_label.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a backticked bare path inside a fence is not reported" {
+    run_measure links "${FIXTURES_DIR}/links/bare_path_fenced.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+# --- scope ---
+
+@test "an existing file without the markdown suffix contributes no surface in links mode" {
+    run_measure links "${FIXTURES_DIR}/scope/notes.txt" "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_success
+    assert_line --index 0 '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+# --- budget flags ---
+
+@test "budget flags are accepted and ignored by links mode" {
+    run_measure links --goal 1 --limit 1 --ceiling 1 --max-index-rows 1 "${FIXTURES_DIR}/links/resolving_link.md"
+
+    assert_success
+    assert_output --partial '1 files scanned, 1 citations found, 1 resolved, 0 findings'
+}
+
+# --- known-positive fixture guard ---
+
+@test "a scope without any citation reports the fixture failure on stderr" {
+    run_measure links "${FIXTURES_DIR}/links/no_citation.md"
+
+    assert_success
+    assert_stderr_contains 'FIXTURE FAILURE: no citation matched anywhere in scope'
+}
+
+@test "a scope without any citation reports the broken-sweep finding" {
+    run_measure links "${FIXTURES_DIR}/links/no_citation.md"
+
+    assert_success
+    assert_output --partial 'sweep matched nothing; the check itself is broken'
+}
+
+@test "a scope without any citation prints no summary line" {
+    run_measure links "${FIXTURES_DIR}/links/no_citation.md"
+
+    assert_success
+    refute_output --partial 'files scanned'
+}
+
+@test "a scope without any citation fails under strict mode" {
+    run_measure links --strict "${FIXTURES_DIR}/links/no_citation.md"
+
+    assert_failure 1
+    assert_output --partial 'sweep matched nothing; the check itself is broken'
+}
+
+@test "the broken-sweep path emits exactly one finding, printed as the exact literal line" {
+    run_measure links --strict "${FIXTURES_DIR}/links/no_citation.md"
+
+    assert_failure 1
+    assert_line --index 0 '  .:0: sweep matched nothing; the check itself is broken'
+    assert_equal "${#lines[@]}" 1
+}

--- a/plugin-tests/shopware-documentation/measure_links.bats
+++ b/plugin-tests/shopware-documentation/measure_links.bats
@@ -36,6 +36,7 @@ load 'test_helper/common_setup'
 
     assert_success
     assert_line --index 0 '1 files scanned, 2 citations found, 2 resolved, 0 findings'
+    assert_equal "${#lines[@]}" 1
 }
 
 @test "a link with an empty target and no anchor resolves against the citing surface" {
@@ -117,6 +118,13 @@ load 'test_helper/common_setup'
 
 @test "a heading with a trailing ATX closer resolves via its stripped slug" {
     run_measure links "${FIXTURES_DIR}/links/anchor_trailing_hash.md"
+
+    assert_success
+    assert_output --partial '1 citations found, 1 resolved, 0 findings'
+}
+
+@test "a heading with a trailing ATX closer followed by trailing whitespace resolves via its stripped slug" {
+    run_measure links "${FIXTURES_DIR}/links/anchor_heading_trailing_space.md"
 
     assert_success
     assert_output --partial '1 citations found, 1 resolved, 0 findings'
@@ -242,5 +250,14 @@ load 'test_helper/common_setup'
 
     assert_failure 1
     assert_line --index 0 '  .:0: sweep matched nothing; the check itself is broken'
+    assert_equal "${#lines[@]}" 1
+}
+
+@test "a scope with a bare-path finding but no citation reports only the broken-sweep finding" {
+    run_measure links --strict "${FIXTURES_DIR}/links/bare_path_no_citation.md"
+
+    assert_failure 1
+    assert_line --index 0 '  .:0: sweep matched nothing; the check itself is broken'
+    refute_output --partial 'bare path is not a cross-reference'
     assert_equal "${#lines[@]}" 1
 }

--- a/plugin-tests/shopware-documentation/measure_size.bats
+++ b/plugin-tests/shopware-documentation/measure_size.bats
@@ -1,0 +1,354 @@
+#!/usr/bin/env bats
+# bats file_tags=shopware-documentation,measure-size
+# `size` mode: budget verdicts, routing-row subtraction, size markers, and the
+# fixed-width report format.
+bats_require_minimum_version 1.11.0
+
+load 'test_helper/common_setup'
+
+setup() {
+    cd "${BATS_TEST_TMPDIR}" || fail "could not enter ${BATS_TEST_TMPDIR}"
+}
+
+# --- verdicts at the default budget boundaries ---
+
+@test "a surface exactly at the goal is verdict goal" {
+    make_counted_md 'surface.md' 5000
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  goal'
+}
+
+@test "a surface one character above the goal is verdict allowed" {
+    make_counted_md 'surface.md' 5001
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  allowed'
+}
+
+@test "a surface exactly at the limit is verdict allowed" {
+    make_counted_md 'surface.md' 6500
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  allowed'
+}
+
+@test "a surface one character above the limit is verdict allowance" {
+    make_counted_md 'surface.md' 6501
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  allowance'
+}
+
+@test "a surface exactly at the ceiling is verdict allowance" {
+    make_counted_md 'surface.md' 10000
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  allowance'
+}
+
+@test "a surface one character above the ceiling is verdict over" {
+    make_counted_md 'surface.md' 10001
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  over'
+}
+
+# --- budget flags ---
+
+@test "a raised goal brings an allowance-sized surface back to goal" {
+    make_counted_md 'surface.md' 7000
+
+    run_measure size --goal 8000 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  goal'
+}
+
+@test "a raised limit brings an allowance-sized surface down to allowed" {
+    make_counted_md 'surface.md' 7000
+
+    run_measure size --limit 8000 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  allowed'
+}
+
+@test "a lowered ceiling pushes an allowance-sized surface over" {
+    make_counted_md 'surface.md' 7000
+
+    run_measure size --ceiling 6000 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  over'
+}
+
+@test "routing rows above the configured maximum are a finding" {
+    make_two_row_index 'index.md'
+
+    run_measure size --max-index-rows 1 'index.md'
+
+    assert_success
+    assert_output --partial '2 routing rows above the 1 maximum'
+}
+
+@test "a pointer file exceeding the routing-row maximum still yields the finding" {
+    make_two_row_index 'AGENTS.md'
+
+    run_measure size --max-index-rows 1 'AGENTS.md'
+
+    assert_success
+    assert_output --partial '2 routing rows above the 1 maximum'
+}
+
+# --- routing rows ---
+
+@test "routing rows are subtracted from a regular surface's counted total" {
+    make_two_row_index 'index.md'
+
+    run_measure size 'index.md'
+
+    assert_success
+    assert_line --index 1 '       9       47     2  goal                   index.md'
+}
+
+@test "a pointer file counts its routing rows toward its total" {
+    make_two_row_index 'AGENTS.md'
+
+    run_measure size 'AGENTS.md'
+
+    assert_success
+    assert_line --index 1 '      47       47     2  goal                   AGENTS.md'
+}
+
+@test "CLAUDE.md is recognised as a pointer file" {
+    make_two_row_index 'CLAUDE.md'
+
+    run_measure size 'CLAUDE.md'
+
+    assert_success
+    assert_line --index 1 '      47       47     2  goal                   CLAUDE.md'
+}
+
+@test "every routing-row marker form is tallied" {
+    run_measure size --max-index-rows 0 "${FIXTURES_DIR}/rows/all_markers.md"
+
+    assert_success
+    assert_output --partial '5 routing rows above the 0 maximum'
+}
+
+@test "a link in running prose is not a routing row" {
+    run_measure size --max-index-rows 0 "${FIXTURES_DIR}/rows/plain_paragraph.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
+@test "a list item whose only link is not markdown is not a routing row" {
+    run_measure size --max-index-rows 0 "${FIXTURES_DIR}/rows/non_md_link.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
+@test "a list item carrying two sentences of prose is not a routing row" {
+    run_measure size --max-index-rows 0 "${FIXTURES_DIR}/rows/two_sentences.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
+@test "a list item inside a fence is not a routing row" {
+    run_measure size --max-index-rows 0 "${FIXTURES_DIR}/rows/fenced_row.md"
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
+# --- size markers ---
+
+@test "a size-exempt marker makes the surface exempt" {
+    make_counted_md 'surface.md' 10001 '<!-- size-exempt: storefront-team -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'exempt     parsed'
+}
+
+@test "a size-allowance marker with the lookup criterion justifies the allowance" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance: lookup -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'allowance  lookup'
+}
+
+@test "a size-allowance marker with the contiguous criterion justifies the allowance" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance: contiguous -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'allowance  contiguous'
+}
+
+@test "a size-allowance marker with the atomic criterion justifies the allowance" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance: atomic -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'allowance  atomic'
+}
+
+@test "a size-allowance marker with trailing content after the criterion is recognised" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance: lookup - one entry per item -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'allowance  lookup'
+}
+
+@test "the first size-allowance marker in the file wins" {
+    make_counted_md 'surface.md' 7000 \
+        '<!-- size-allowance: lookup -->' '<!-- size-allowance: atomic -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial 'allowance  lookup'
+}
+
+@test "a size-allowance marker split across two lines is not recognised" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance:' 'atomic -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '7000 chars above the 6500 limit with no allowance marker'
+}
+
+@test "a size-exempt marker split across two lines is not recognised" {
+    make_counted_md 'surface.md' 10001 '<!-- size-exempt:' 'storefront-team -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '10001 chars above the 10000 ceiling; splits regardless of any marker'
+}
+
+@test "a surface in the allowance band without a marker is a finding" {
+    make_counted_md 'surface.md' 7000
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '7000 chars above the 6500 limit with no allowance marker'
+}
+
+@test "a surface above the ceiling is a finding despite an allowance marker" {
+    make_counted_md 'surface.md' 10001 '<!-- size-allowance: atomic -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '10001 chars above the 10000 ceiling; splits regardless of any marker'
+}
+
+@test "a surface with both an exempt marker and an allowance marker is exempt with the allowance criterion" {
+    make_counted_md 'surface.md' 10001 \
+        '<!-- size-exempt: storefront-team -->' '<!-- size-allowance: lookup -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_line --index 1 '   10001    10001     0  exempt     lookup      surface.md'
+}
+
+# --- report format ---
+
+@test "the report opens with the column header" {
+    make_counted_md 'surface.md' 5000
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_line --index 0 ' counted      raw  rows  verdict    criterion   path'
+}
+
+@test "surfaces are listed by descending counted total" {
+    make_counted_md 'small.md' 5000
+    make_counted_md 'large.md' 6000
+
+    run_measure size 'small.md' 'large.md'
+
+    assert_success
+    assert_line --index 1 --partial 'large.md'
+    assert_line --index 2 --partial 'small.md'
+}
+
+@test "a scope of one surface is summarised in the singular" {
+    make_counted_md 'surface.md' 5000
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_line --index 3 '1 surface measured, 0 findings'
+}
+
+@test "a scope of several surfaces is summarised in the plural" {
+    make_counted_md 'small.md' 5000
+    make_counted_md 'large.md' 6000
+
+    run_measure size 'small.md' 'large.md'
+
+    assert_success
+    assert_line --index 4 '2 surfaces measured, 0 findings'
+}
+
+@test "findings are listed indented under the summary" {
+    make_counted_md 'oversized.md' 10001
+
+    run_measure size 'oversized.md'
+
+    assert_success
+    assert_line --index 4 '  oversized.md: 10001 chars above the 10000 ceiling; splits regardless of any marker'
+}
+
+@test "the criterion column is exactly 11 characters wide for a non-empty criterion" {
+    make_counted_md 'surface.md' 7000 '<!-- size-allowance: lookup -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_line --index 1 '    7000     7000     0  allowance  lookup      surface.md'
+}
+
+@test "findings from multiple files are ordered by row then by each file's own finding order" {
+    make_counted_md 'big.md' 10100 '- [link](target.md)'
+    make_counted_md 'small.md' 7020 '- [link](target.md)'
+
+    run_measure size --max-index-rows 0 'big.md' 'small.md'
+
+    assert_success
+    assert_line --index 4 '2 surfaces measured, 4 findings'
+    assert_line --index 5 '  big.md: 10080 chars above the 10000 ceiling; splits regardless of any marker'
+    assert_line --index 6 '  big.md: 1 routing rows above the 0 maximum'
+    assert_line --index 7 '  small.md: 7000 chars above the 6500 limit with no allowance marker'
+    assert_line --index 8 '  small.md: 1 routing rows above the 0 maximum'
+}

--- a/plugin-tests/shopware-documentation/measure_size.bats
+++ b/plugin-tests/shopware-documentation/measure_size.bats
@@ -113,6 +113,24 @@ setup() {
     assert_output --partial '2 routing rows above the 1 maximum'
 }
 
+@test "with no --max-index-rows flag, twenty-one routing rows produce the default-maximum finding" {
+    make_n_row_index 'index.md' 21
+
+    run_measure size 'index.md'
+
+    assert_success
+    assert_output --partial '21 routing rows above the 20 maximum'
+}
+
+@test "with no --max-index-rows flag, twenty routing rows produce no routing-rows finding" {
+    make_n_row_index 'index.md' 20
+
+    run_measure size 'index.md'
+
+    assert_success
+    assert_output --partial '1 surface measured, 0 findings'
+}
+
 # --- routing rows ---
 
 @test "routing rows are subtracted from a regular surface's counted total" {
@@ -280,6 +298,36 @@ setup() {
     assert_line --index 1 '   10001    10001     0  exempt     lookup      surface.md'
 }
 
+@test "size markers inside a fenced block are not recognised" {
+    make_counted_md 'surface.md' 10001 \
+        '```' '<!-- size-exempt: storefront-team -->' '<!-- size-allowance: lookup -->' '```'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  over'
+    assert_output --partial '10001 chars above the 10000 ceiling; splits regardless of any marker'
+}
+
+@test "a size-exempt marker with empty consumer text is not recognised" {
+    make_counted_md 'surface.md' 10001 '<!-- size-exempt: -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_output --partial '    0  over'
+    assert_output --partial '10001 chars above the 10000 ceiling; splits regardless of any marker'
+}
+
+@test "a size-allowance marker on a surface within the goal band still shows its criterion" {
+    make_counted_md 'surface.md' 5000 '<!-- size-allowance: lookup -->'
+
+    run_measure size 'surface.md'
+
+    assert_success
+    assert_line --index 1 '    5000     5000     0  goal       lookup      surface.md'
+}
+
 # --- report format ---
 
 @test "the report opens with the column header" {
@@ -309,6 +357,7 @@ setup() {
 
     assert_success
     assert_line --index 3 '1 surface measured, 0 findings'
+    assert_equal "${#lines[@]}" 4
 }
 
 @test "a scope of several surfaces is summarised in the plural" {
@@ -319,6 +368,7 @@ setup() {
 
     assert_success
     assert_line --index 4 '2 surfaces measured, 0 findings'
+    assert_equal "${#lines[@]}" 5
 }
 
 @test "findings are listed indented under the summary" {

--- a/plugin-tests/shopware-documentation/test_helper/common_setup.bash
+++ b/plugin-tests/shopware-documentation/test_helper/common_setup.bash
@@ -79,3 +79,20 @@ make_two_row_index() {
         fail "make_two_row_index: wrote ${actual} chars to ${target}, expected 47"
     fi
 }
+
+# Write an index file with exactly ${count} routing rows: a heading, a blank
+# line, then ${count} list-item rows, each a distinct one-link citation with
+# no sentence-ending punctuation, so every row qualifies as a routing row.
+make_n_row_index() {
+    local target="$1"
+    local count="$2"
+
+    {
+        printf '%s\n' '# Index' ''
+        local i=1
+        while [[ "${i}" -le "${count}" ]]; do
+            printf -- '- [Item %d](item-%d.md)\n' "${i}" "${i}"
+            i=$((i + 1))
+        done
+    } > "${target}"
+}

--- a/plugin-tests/shopware-documentation/test_helper/common_setup.bash
+++ b/plugin-tests/shopware-documentation/test_helper/common_setup.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Fixtures for the shopware-documentation measure.sh suite.
+
+load "${BATS_TEST_DIRNAME}/../test_helper/common_setup"
+
+MEASURE_SH="${REPO_ROOT}/plugins/shopware-documentation/skills/structuring-documentation/scripts/measure.sh"
+FIXTURES_DIR="${BATS_TEST_DIRNAME}/fixtures"
+
+# Invoke measure.sh, keeping stdout and stderr apart so that usage and
+# path errors can be asserted on the stream the contract names.
+# Sets: $status, $output (stdout), $stderr
+run_measure() {
+    run --keep-empty-lines --separate-stderr "${MEASURE_SH}" "$@"
+}
+
+# Assert that the captured stderr contains a substring.
+assert_stderr_contains() {
+    local expected="$1"
+
+    if [[ "${stderr}" != *"${expected}"* ]]; then
+        printf 'expected stderr to contain: %s\n' "${expected}"
+        printf 'actual stderr: %s\n' "${stderr}"
+        fail "stderr did not contain the expected text"
+    fi
+}
+
+# Write a markdown file whose character count is exactly ${total}.
+#
+#   make_counted_md <target> <total> [extra_line ...]
+#
+# The file is a heading, a blank line, each extra_line verbatim, then a single
+# padding line of 'x' characters sized so the total lands on ${total}. Extra
+# lines carry markers or citations when a test needs them. None of the
+# generated lines is a routing row, so counted equals total for regular files.
+#
+# Fails the test loudly when the requested total cannot be produced or when the
+# file on disk does not have the requested byte count.
+make_counted_md() {
+    local target="$1"
+    local total="$2"
+    shift 2
+
+    local prelude='# Sized surface
+
+'
+    local extra_line
+    for extra_line in "$@"; do
+        prelude="${prelude}${extra_line}"$'\n'
+    done
+
+    local filler_len=$(( total - ${#prelude} - 1 ))
+    if [[ "${filler_len}" -lt 0 ]]; then
+        fail "make_counted_md: total ${total} is too small for the ${#prelude} chars already required by ${target}"
+    fi
+
+    {
+        printf '%s' "${prelude}"
+        printf '%*s' "${filler_len}" '' | tr ' ' 'x'
+        printf '\n'
+    } > "${target}"
+
+    local actual
+    actual="$(wc -c < "${target}" | tr -d ' ')"
+    if [[ "${actual}" -ne "${total}" ]]; then
+        fail "make_counted_md: wrote ${actual} chars to ${target}, expected ${total}"
+    fi
+}
+
+# Write a two-row index file: 47 raw characters, 2 routing rows of 19 and 17
+# characters, so counted is 47 - 20 - 18 = 9 for a regular file.
+make_two_row_index() {
+    local target="$1"
+
+    printf '%s\n' '# Index' '' '- [Alpha](alpha.md)' '- [Beta](beta.md)' > "${target}"
+
+    local actual
+    actual="$(wc -c < "${target}" | tr -d ' ')"
+    if [[ "${actual}" -ne 47 ]]; then
+        fail "make_two_row_index: wrote ${actual} chars to ${target}, expected 47"
+    fi
+}

--- a/plugins/shopware-documentation/.claude-plugin/plugin.json
+++ b/plugins/shopware-documentation/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "shopware-documentation",
+  "version": "1.0.0",
+  "description": "Documentation-surface structuring for Shopware repositories. Size budgets, one subject per file, splitting oversized surfaces into docs/ siblings, and cross-reference integrity, backed by a measurement script.",
+  "author": { "name": "Shopware Labs" },
+  "license": "MIT",
+  "keywords": ["documentation", "docs", "readme", "agents-md", "budgets", "markdown", "shopware"],
+  "homepage": "https://github.com/shopwareLabs/ai-coding-tools/tree/main/plugins/shopware-documentation",
+  "repository": "https://github.com/shopwareLabs/ai-coding-tools"
+}

--- a/plugins/shopware-documentation/AGENTS.md
+++ b/plugins/shopware-documentation/AGENTS.md
@@ -1,0 +1,39 @@
+@README.md
+
+## Directory Structure
+
+```
+plugins/shopware-documentation/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   └── structuring-documentation/
+│       ├── SKILL.md
+│       ├── .agent-skills
+│       ├── references/
+│       │   ├── surface-contract.md
+│       │   └── splitting.md
+│       └── scripts/
+│           └── measure.sh
+├── README.md
+├── AGENTS.md                            # This file
+├── CLAUDE.md
+└── CHANGELOG.md
+```
+
+## Runtime vs Developer Docs
+
+| Runtime (executed or loaded by the skill)                          | Developer docs (human reference only) |
+|----------------------------------------------------------------------|------------------------------------------|
+| `skills/structuring-documentation/SKILL.md`                          | `README.md`                              |
+| `skills/structuring-documentation/references/surface-contract.md`    | `AGENTS.md` (this file)                  |
+| `skills/structuring-documentation/references/splitting.md`           | `CLAUDE.md`                              |
+| `skills/structuring-documentation/scripts/measure.sh`                | `CHANGELOG.md`                           |
+
+## Tests
+
+Tests live in `plugin-tests/shopware-documentation/`: `measure_cli.bats`, `measure_size.bats`, `measure_links.bats`, plus fixtures under `fixtures/`. Run via `.bats/bats-core/bin/bats plugin-tests/shopware-documentation/*.bats` from the repo root.
+
+## Version Sync
+
+`plugin.json` version, the `structuring-documentation` skill's `SKILL.md` frontmatter version, and the latest `CHANGELOG.md` entry stay in lockstep. Bump all three together; see the `plugin-updating` skill.

--- a/plugins/shopware-documentation/AGENTS.md
+++ b/plugins/shopware-documentation/AGENTS.md
@@ -1,4 +1,6 @@
-@README.md
+> Conceptual overview and design rationale for this module live in `README.md`
+> (same directory). The references and constraints below are sufficient for most
+> code changes; read the README only when you need the mental model.
 
 ## Directory Structure
 
@@ -17,18 +19,19 @@ plugins/shopware-documentation/
 │           └── measure.sh
 ├── README.md
 ├── AGENTS.md                            # This file
-├── CLAUDE.md
 └── CHANGELOG.md
 ```
 
+A local `CLAUDE.md` containing `@AGENTS.md` may sit beside this file. It is gitignored repo-wide, so it stays untracked by convention and never ships with the plugin.
+
 ## Runtime vs Developer Docs
 
-| Runtime (executed or loaded by the skill)                          | Developer docs (human reference only) |
-|----------------------------------------------------------------------|------------------------------------------|
-| `skills/structuring-documentation/SKILL.md`                          | `README.md`                              |
-| `skills/structuring-documentation/references/surface-contract.md`    | `AGENTS.md` (this file)                  |
-| `skills/structuring-documentation/references/splitting.md`           | `CLAUDE.md`                              |
-| `skills/structuring-documentation/scripts/measure.sh`                | `CHANGELOG.md`                           |
+| Runtime (executed or loaded by the skill)                         | Developer docs (human reference only) |
+|-------------------------------------------------------------------|---------------------------------------|
+| `skills/structuring-documentation/SKILL.md`                       | `README.md`                           |
+| `skills/structuring-documentation/references/surface-contract.md` | `AGENTS.md` (this file)               |
+| `skills/structuring-documentation/references/splitting.md`        | `CHANGELOG.md`                        |
+| `skills/structuring-documentation/scripts/measure.sh`             |                                       |
 
 ## Tests
 

--- a/plugins/shopware-documentation/CHANGELOG.md
+++ b/plugins/shopware-documentation/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.0.0] - 2026-08-13
+
+### Added
+- Initial release of shopware-documentation plugin
+- `structuring-documentation` skill with size budgets, allowance criteria, cross-reference rules, and the per-directory surface layout
+- Surface contract reference covering content classes, the single-home rule, `AGENTS.md` bullet discipline, subject ownership, and `docs/` naming
+- Splitting reference covering the split procedure, heading promotion, the four post-split defect classes, and the sweep discipline

--- a/plugins/shopware-documentation/README.md
+++ b/plugins/shopware-documentation/README.md
@@ -1,0 +1,61 @@
+# Shopware Documentation
+
+Structuring skill for Markdown documentation surfaces in Shopware repositories. Keeps every `README.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/` sibling at one subject, one content class, and a bounded amount of reading — measured, not estimated.
+
+## 📦 Installation
+
+```bash
+/plugin install shopware-documentation@shopware-ai-coding-tools
+```
+
+## ⚡ Quick Start
+
+The `structuring-documentation` skill activates automatically when documentation surfaces are written, audited, or split:
+
+```
+Is this README too long?
+Split src/Core/Framework/ContentSystem/README.md
+Measure the docs under src/Storefront/ContentSystem
+Where does this documentation belong?
+```
+
+## 🗜️ Measurement Script
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" <size|links|all> [flags] PATH...
+```
+
+`${CLAUDE_SKILL_DIR}` resolves to the installed skill's directory at runtime; when running the script by hand, substitute the path to `skills/structuring-documentation` yourself.
+
+| Mode    | Reports                                                                                                                                                                                                          |
+|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `size`  | counted characters, raw characters, routing rows, and a budget verdict per surface                                                                                                                               |
+| `links` | every relative Markdown cross-reference and anchor resolved from the citing file's position (web and mail links [http, https, mailto] and non-`.md` targets skipped by design), plus backticked bare `.md` paths |
+| `all`   | both                                                                                                                                                                                                             |
+
+| Flag                 | Effect                                                   |
+|----------------------|----------------------------------------------------------|
+| `--goal N`           | at-goal budget, default 5000 counted characters          |
+| `--limit N`          | allowed budget, default 6500                             |
+| `--ceiling N`        | never-ships budget, default 10000                        |
+| `--max-index-rows N` | routing rows an index may carry, default 20              |
+| `--strict`           | exit 1 on any finding instead of reporting and exiting 0 |
+
+> [!NOTE]
+> The script has no default scope. Every invocation names the paths to measure.
+
+## 🎛️ Scope and Budget Overrides
+
+Scope is supplied per invocation: the paths named in the request, or the documentation files the current change touches. When no scope is stated, the skill asks instead of assuming one.
+
+Budgets are named values — `docs.size_goal`, `docs.size_limit`, `docs.size_ceiling`, `docs.max_index_rows` — that a project or a user instruction may assign. Assigned values are passed to the script as `--goal`, `--limit`, `--ceiling`, and `--max-index-rows`; unassigned, the script's built-in defaults apply. A project may also supply its own subject-ownership table, which the skill consults wherever ownership decides where a fact lives.
+
+## 📚 Documentation
+
+- **Core skill**: [skills/structuring-documentation/SKILL.md](skills/structuring-documentation/SKILL.md)
+- **Surface contract**: [skills/structuring-documentation/references/surface-contract.md](skills/structuring-documentation/references/surface-contract.md)
+- **Splitting procedure**: [skills/structuring-documentation/references/splitting.md](skills/structuring-documentation/references/splitting.md)
+
+## ⚖️ License
+
+MIT

--- a/plugins/shopware-documentation/README.md
+++ b/plugins/shopware-documentation/README.md
@@ -33,6 +33,8 @@ bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" <size|links|all> [flags] PATH...
 | `links` | every relative Markdown cross-reference and anchor resolved from the citing file's position (web and mail links [http, https, mailto] and non-`.md` targets skipped by design), plus backticked bare `.md` paths |
 | `all`   | both                                                                                                                                                                                                             |
 
+Counts are taken on the raw file in bytes; for the ASCII documentation this skill governs bytes are characters, and non-ASCII text counts by its encoded size.
+
 | Flag                 | Effect                                                   |
 |----------------------|----------------------------------------------------------|
 | `--goal N`           | at-goal budget, default 5000 counted characters          |

--- a/plugins/shopware-documentation/skills/structuring-documentation/SKILL.md
+++ b/plugins/shopware-documentation/skills/structuring-documentation/SKILL.md
@@ -23,37 +23,49 @@ digraph doc_surfaces {
   start [shape=doublecircle, label="editing or auditing\na doc surface"];
   scope [label="determine the surfaces in scope\n(ask when none is stated)"];
   measure [label="run measure.sh size + links"];
+  subjects [shape=diamond, label="each surface holds one subject,\nowned by its directory\n(references/surface-contract.md)?"];
+  rehome [label="split the surface, or move the\nsubject to its owning directory"];
   over [shape=diamond, label="verdict over\n(above docs.size_ceiling, 10000)?"];
   limit [shape=diamond, label="verdict allowance\n(above docs.size_limit, 6500)?"];
   crit [shape=diamond, label="is a criterion\ntrue of this file?"];
   goal [shape=diamond, label="verdict allowed\n(above docs.size_goal, 5000) with an\nobvious section boundary?"];
   split [label="split into docs/ siblings\n(references/splitting.md)"];
-  mark [label="mark the allowance\nunder the title"];
-  stop [shape=octagon, style=filled, fillcolor=red, label="STOP: length alone is not\na criterion, and neither is\npreferring not to split"];
-  links [label="convert every .md citation\nto a relative link"];
+  nocrit [label="no criterion holds: length alone\nis not one, and neither is\npreferring not to split — split"];
+  mark [label="mark the allowance or exemption\nunder the title (for size-exempt,\nverify the parsing consumer first)"];
+  rows [shape=diamond, label="routing rows above\ndocs.max_index_rows (20)?"];
+  group [label="introduce an\nintermediate grouping"];
+  links [label="repair citations: convert bare paths,\nfix dead targets and stale anchors,\nrelink restating anchors"];
   moved [shape=diamond, label="did this change create a directory\nor move a section body?"];
   sweep [label="run the three sweeps, then run\nthem again after the repairs"];
   recheck [label="re-run measure.sh"];
-  done [shape=doublecircle, label="findings resolved"];
+  resolved [shape=diamond, label="every finding repaired, or\ndismissed with a stated reason?"];
+  done [shape=doublecircle, label="findings resolved\nor dismissed"];
 
-  start -> scope -> measure -> over;
+  start -> scope -> measure -> subjects;
+  subjects -> rehome [label=" no"];
+  rehome -> over;
+  subjects -> over [label=" yes"];
   over -> split [label=" yes"];
   over -> limit [label=" no"];
   limit -> crit [label=" yes"];
   limit -> goal [label=" no"];
   crit -> mark [label=" yes"];
-  crit -> stop [label=" no"];
-  stop -> split;
+  crit -> nocrit [label=" no"];
+  nocrit -> split;
   goal -> split [label=" yes"];
-  goal -> links [label=" no"];
-  split -> links;
-  mark -> links;
+  goal -> rows [label=" no"];
+  split -> rows;
+  mark -> rows;
+  rows -> group [label=" yes"];
+  group -> links;
+  rows -> links [label=" no"];
   links -> moved;
   moved -> sweep [label=" yes"];
   moved -> recheck [label=" no"];
   sweep -> recheck;
-  recheck -> over [label=" findings remain"];
-  recheck -> done [label=" none"];
+  recheck -> resolved;
+  resolved -> over [label=" no"];
+  resolved -> done [label=" yes"];
 }
 ```
 
@@ -77,9 +89,17 @@ bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" all --goal 4000 <Module> <Module>/
 
 Read the actual output. A surface is inside its budget when the tool says so, not when the edit felt small.
 
+Resolve every finding by repairing it, or dismiss it with a stated reason. Dismissal is for findings the rules themselves exempt — a bare backticked path naming an instruction's operand — and for surfaces outside the change's scope. The workflow ends when every finding is repaired or dismissed; `--strict` is a machine gate, not that exit condition.
+
+## One subject per surface
+
+Every surface in scope holds one subject, and the directory it sits in owns that subject. Read `references/surface-contract.md` to test ownership. A surface holding two subjects splits; a subject documented in the wrong directory moves to its owner.
+
+An audit runs this check over every surface in scope, not only the ones the change edited.
+
 ## Budgets
 
-Counted on the raw file, in characters.
+Counted on the raw file, in bytes. For the ASCII documentation this skill governs, bytes are characters; non-ASCII text counts by its encoded size.
 
 | Counted characters | Verdict |
 |---|---|
@@ -114,7 +134,9 @@ A surface a machine consumer reads whole or parses structurally is exempt outrig
 
 Every reference to another Markdown file is a relative Markdown link: `[Error codes](docs/error-codes.md)`.
 
-Add an anchor only when the target is a section inside a larger file. An anchor whose slug equals the target file's own title is always wrong: it resolves today, breaks the moment that title is reworded, and buys nothing.
+Add an anchor only when the target is a section inside a larger file. An anchor whose slug equals the target file's own name is always wrong: it adds nothing over linking the file, and breaks the moment that heading is reworded.
+
+A link whose target no longer exists, or whose anchor no longer matches a heading, is repaired to the content's current location. Content that is gone takes its citing sentence with it.
 
 A backticked bare path is not a cross-reference. Convert every one that sends a reader somewhere. A path named as the operand of an instruction stays bare: "edit `services.xml`" names the file to act on, not a place to read.
 
@@ -134,7 +156,7 @@ Never cite a line number.
 └── docs/       configuration reference, one subject per file
 ```
 
-`CLAUDE.md` contains `@AGENTS.md` and nothing else.
+`CLAUDE.md` contains `@AGENTS.md` and nothing else, unless project extension content names a module-root exception (a work-in-progress status line, for example).
 
 `AGENTS.md` never imports `README.md`. An `@` import inlines its target in full, so importing human prose pays for it in every session. `AGENTS.md` points at the README by name instead, with this line verbatim:
 
@@ -153,3 +175,7 @@ Read `references/surface-contract.md` before moving a proposition between files,
 ## Splitting a surface
 
 Read `references/splitting.md` before moving any `##` section into a new file. It carries the split procedure, the directory and file naming rules, heading promotion, and the four post-split defect classes that no content check finds.
+
+## After a move
+
+A change that created a directory or moved a section body runs the three sweeps in `references/splitting.md`, then runs them again after the repairs. Re-run `measure.sh` afterwards, and walk the report again until every finding is repaired or dismissed.

--- a/plugins/shopware-documentation/skills/structuring-documentation/SKILL.md
+++ b/plugins/shopware-documentation/skills/structuring-documentation/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: structuring-documentation
+version: 1.0.0
+description: Use when writing, editing, auditing, splitting, or measuring Markdown documentation surfaces — README.md, AGENTS.md, CLAUDE.md, and docs/ siblings. Triggers include "is this doc too long", "split this README", "measure the docs", "where does this documentation belong", "audit the documentation", and any request to check a documentation file against a size budget or repair its cross-references.
+license: MIT
+---
+
+# Structuring Documentation
+
+Treat every Markdown file in scope as a documentation surface. Each one holds one subject, one content class, and a bounded amount of reading.
+
+The surfaces in scope are the paths the user names, or the documentation files the current change touches. The script has no default scope and requires explicit paths. When no scope is stated, ask for it rather than assuming one.
+
+Nothing here gates a build. The measurement reports; you act on what it reports.
+
+Budgets are named values: `docs.size_goal` (default if not otherwise stated: 5000), `docs.size_limit` (6500), `docs.size_ceiling` (10000), `docs.max_index_rows` (20). When earlier context or a user instruction assigns a different value, pass it to the script as `--goal`, `--limit`, `--ceiling`, or `--max-index-rows`; otherwise run the script on its built-in defaults. When earlier context supplies a subject-ownership table for the project, use it wherever the workflow consults ownership.
+
+## Workflow
+
+```dot
+digraph doc_surfaces {
+  node [shape=box];
+  start [shape=doublecircle, label="editing or auditing\na doc surface"];
+  scope [label="determine the surfaces in scope\n(ask when none is stated)"];
+  measure [label="run measure.sh size + links"];
+  over [shape=diamond, label="verdict over\n(above docs.size_ceiling, 10000)?"];
+  limit [shape=diamond, label="verdict allowance\n(above docs.size_limit, 6500)?"];
+  crit [shape=diamond, label="is a criterion\ntrue of this file?"];
+  goal [shape=diamond, label="verdict allowed\n(above docs.size_goal, 5000) with an\nobvious section boundary?"];
+  split [label="split into docs/ siblings\n(references/splitting.md)"];
+  mark [label="mark the allowance\nunder the title"];
+  stop [shape=octagon, style=filled, fillcolor=red, label="STOP: length alone is not\na criterion, and neither is\npreferring not to split"];
+  links [label="convert every .md citation\nto a relative link"];
+  moved [shape=diamond, label="did this change create a directory\nor move a section body?"];
+  sweep [label="run the three sweeps, then run\nthem again after the repairs"];
+  recheck [label="re-run measure.sh"];
+  done [shape=doublecircle, label="findings resolved"];
+
+  start -> scope -> measure -> over;
+  over -> split [label=" yes"];
+  over -> limit [label=" no"];
+  limit -> crit [label=" yes"];
+  limit -> goal [label=" no"];
+  crit -> mark [label=" yes"];
+  crit -> stop [label=" no"];
+  stop -> split;
+  goal -> split [label=" yes"];
+  goal -> links [label=" no"];
+  split -> links;
+  mark -> links;
+  links -> moved;
+  moved -> sweep [label=" yes"];
+  moved -> recheck [label=" no"];
+  sweep -> recheck;
+  recheck -> over [label=" findings remain"];
+  recheck -> done [label=" none"];
+}
+```
+
+## Measure
+
+```
+bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" <size|links|all> [flags] PATH...
+```
+
+```
+bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" size <Module>/README.md <Module>/AGENTS.md
+bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" links --strict <Module>
+bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" all --goal 4000 <Module> <Module>/docs
+```
+
+`${CLAUDE_SKILL_DIR}` is this skill's own directory; on a host that does not define it, substitute the path to this skill's directory.
+
+`size` reports counted characters, raw characters, routing rows, and a verdict per surface. `links` resolves every relative Markdown cross-reference and its anchor from the citing file's own position — web and mail links (http, https, mailto) and non-`.md` targets are skipped by design — and reports every backticked bare `.md` path with whether it resolves.
+
+`--strict` exits 1 on any finding. Use it when you want a failing command; the default reports and exits 0.
+
+Read the actual output. A surface is inside its budget when the tool says so, not when the edit felt small.
+
+## Budgets
+
+Counted on the raw file, in characters.
+
+| Counted characters | Verdict |
+|---|---|
+| up to `docs.size_goal` (5,000) | at goal |
+| `docs.size_goal` to `docs.size_limit` (5,001 to 6,500) | allowed; split when a section boundary is already obvious |
+| `docs.size_limit` to `docs.size_ceiling` (6,501 to 10,000) | only against a named allowance criterion, marked in the file and true of it |
+| above `docs.size_ceiling` (10,000) | never ships; the surface owns more than one subject |
+
+The budget is a state, not a threshold an edit crosses. A surface the change touches ends the change inside its budget whatever it measured beforehand. Being oversized already is the reason to split now, not an exemption.
+
+Routing rows do not count: a list item or table row whose content is a link to another Markdown file plus at most one sentence. Past one sentence the whole row counts. `AGENTS.md` and `CLAUDE.md` count every character, routing included.
+
+An index carries at most `docs.max_index_rows` (20) routing rows. Past that the surface wants an intermediate grouping, not more rows.
+
+## Allowances
+
+Mark an allowance in an HTML comment directly under the title. Unmarked, the allowance does not exist and the budget is `docs.size_limit` (6,500).
+
+```markdown
+<!-- size-allowance: lookup - one entry per supported field type, consulted one at a time -->
+```
+
+- `lookup` — one enumeration whose entries share a uniform shape: a list, a table, or repeated same-level headings on one skeleton. Entries are consulted one at a time, never read through.
+- `contiguous` — the sections cite each other by name, so splitting would turn in-file references into mutual cross-file ones.
+- `atomic` — no internal boundary a reader would jump to: no subheading, and nothing standing in for one. A file that writes its sections as bold lead-ins has headings it declined to mark, and is not atomic.
+
+Length alone satisfies none of the three, and neither does preferring not to split. The criterion is a claim about the file's structure that the next reader can check and reject.
+
+A surface a machine consumer reads whole or parses structurally is exempt outright, and its marker names the consumer: `<!-- size-exempt: parsed by <path> -->`. Before claiming this, find the declaration and say what breaks. A file merely mentioned in a comment is not parsed.
+
+## Cross-references
+
+Every reference to another Markdown file is a relative Markdown link: `[Error codes](docs/error-codes.md)`.
+
+Add an anchor only when the target is a section inside a larger file. An anchor whose slug equals the target file's own title is always wrong: it resolves today, breaks the moment that title is reworded, and buys nothing.
+
+A backticked bare path is not a cross-reference. Convert every one that sends a reader somewhere. A path named as the operand of an instruction stays bare: "edit `services.xml`" names the file to act on, not a place to read.
+
+Outside Markdown, in PHP, YAML, or a shell script, cite the bare path with its anchor and no link syntax. Link syntax renders nowhere there.
+
+A citation with more than one target becomes prose. `<Module>/*/README.md` names every subdirectory's README and no link expresses it.
+
+Never cite a line number.
+
+## Structure per directory
+
+```
+<Dir>/
+├── README.md   title, orienting paragraph, explanation, index rows into docs/
+├── AGENTS.md   symbol index, constraints, Navigation, the README pointer line
+├── CLAUDE.md   @AGENTS.md
+└── docs/       configuration reference, one subject per file
+```
+
+`CLAUDE.md` contains `@AGENTS.md` and nothing else.
+
+`AGENTS.md` never imports `README.md`. An `@` import inlines its target in full, so importing human prose pays for it in every session. `AGENTS.md` points at the README by name instead, with this line verbatim:
+
+```
+> Conceptual overview and design rationale for this module live in `README.md`
+> (same directory). The references and constraints below are sufficient for most
+> code changes; read the README only when you need the mental model.
+```
+
+A `docs/` directory is reached by link only. No `@` import targets it. A directory with no reference material carries no `docs/`.
+
+## Which file a fact goes in
+
+Read `references/surface-contract.md` before moving a proposition between files, before adding a section to a `README.md` or an `AGENTS.md`, and before deciding where a new subject lives. It carries the content classes, the single-home rule, and the subject-ownership rule.
+
+## Splitting a surface
+
+Read `references/splitting.md` before moving any `##` section into a new file. It carries the split procedure, the directory and file naming rules, heading promotion, and the four post-split defect classes that no content check finds.

--- a/plugins/shopware-documentation/skills/structuring-documentation/references/splitting.md
+++ b/plugins/shopware-documentation/skills/structuring-documentation/references/splitting.md
@@ -1,0 +1,63 @@
+# Splitting a Surface
+
+Split by moving whole `##` sections into sibling files, leaving the original as the index that routes to them.
+
+## Where the siblings go
+
+A surface splits into a `docs/` directory beside it: `<Module>/README.md` splits into `<Module>/docs/`, `<Module>/<Subdir>/README.md` into `<Module>/<Subdir>/docs/`.
+
+Never name the directory for the file. A directory called `readme/` would be claimed by every module.
+
+## What stays in the index
+
+Keep the title and everything above the first `##`. Those scope the whole surface.
+
+Order the index rows by the original heading order. A surface written to be read through encodes its reading order there, and alphabetising discards it.
+
+Pack adjacent sections together up to the goal (`docs.size_goal`). Never one file per section, unless each resulting file is independently addressable by name and a reader would ask for it by that name. A per-item reference file earns its own file; two unrelated sections packed under an invented compound title do not.
+
+A file whose title restates its only sentence belongs merged back into its neighbour.
+
+## Headings
+
+Drop a moved section's heading when the new file's title already names it, and promote its subsections one level. Carrying the heading across is the default outcome of moving a section into a file that then gets a title, and it produces a file opening with a heading that restates the line above it.
+
+Drop it only after searching the old anchor and confirming nothing cites it.
+
+Every sibling's own sections start at `##`, whatever level they sat at in the source. A section carved out of a `##` section's `###` children arrives with `###` headings under a new `#` title, skipping `##` entirely. Promote them.
+
+Siblings carved from one source section share one heading scheme. Three files from one section that each nest differently no longer read as siblings.
+
+## A single section over budget
+
+A `##` section can exceed the budget alone. Split it at its own internal boundaries, and add a heading where the prose has a boundary it never marked. An invented heading that names what is already there is correct; one that imposes a division the prose does not make is not.
+
+## After the split
+
+Four defect classes survive every content check. Token diffs, word multisets, and duplication scans all compare content, and the content is identical: only the referent moved. Each is caught by reading, or not at all.
+
+**1. Prose that describes its own container.** Text can move verbatim and become false, because it made a claim about the file it used to live in. Re-read every moved passage for "this file", "everything below", "the rest of", "described above", a count of what the document covers, and any sentence telling a future author where to put something.
+
+**2. Pointers that assert what an emptied surface owns.** Re-read anything that pointed *at* a surface whose body moved out: an ownership row, a procedure naming a file by path, another document's routing sentence. The path still resolves, so nothing flags it, and the claim is now false. Look for an assertion verb beside the path: owns, covers, documents, lists, explains, carries, holds, records, details, contains.
+
+**3. Relative citations broken by a new directory.** A bare `<Other>/<Subdir>/README.md` written in `<Module>/README.md` meant one thing while no `<Module>/<Other>/` existed. Creating any new directory changes what a relative path resolves to, in that file, in its `AGENTS.md`, and in every sibling. Re-resolve every relative citation in the files beside a newly created directory, including files the change never opened. A split breaks citations in files it never touched.
+
+**4. A scope sentence contradicted by the body.** The split writes a correct orienting sentence at the top of each new file and leaves the body's own scope statements saying something else, so a file states its scope correctly in line 3 and contradicts it in line 18. Write each new file's orienting sentence from where that file now sits, then reconcile the body against it. That is one step; skipping it produces a contradiction per file.
+
+## Sweeping
+
+Run three searches, then run all three again after fixing what they found.
+
+1. For every heading renamed and every file moved, search the old anchor and the old path, and update each reference in the same change.
+2. For every surface whose body moved out, search its path where it did *not* change, and re-read what each hit claims about it.
+3. For every directory the split creates, re-resolve every relative citation in the files beside it.
+
+The repair for a stale scope sentence is writing a scope sentence, and the repair for a bare path is writing a relative one. Each repair is the same operation that produced the defect, performed by someone who now believes the file is clean. A repair pass that is not re-swept ships the class it was convened to remove.
+
+Search every tracked file, not only the Markdown ones the budget governs. PHP comments, YAML, shell scripts, and runtime error messages cite documentation paths too.
+
+Give any path sweep a known-positive fixture: a citation it must find. A regex written against text that is mostly backticks, punctuation, and slashes can be incapable of matching any real citation while returning the same empty output as a clean tree. `bash "${CLAUDE_SKILL_DIR}/scripts/measure.sh" links <changed directories>` fails loudly when it resolves nothing, for exactly this reason.
+
+## What a split does not license
+
+Prose moved verbatim does not go through a rewrite pass. A prose editor run over text that only changed address will reword domain terms the move never touched. Only prose the split itself writes, a new index row or an invented heading's opening line, is new prose.

--- a/plugins/shopware-documentation/skills/structuring-documentation/references/surface-contract.md
+++ b/plugins/shopware-documentation/skills/structuring-documentation/references/surface-contract.md
@@ -1,0 +1,61 @@
+# Surface Contract
+
+Each surface declares three things: who owns its subject, which content class it holds, and what it costs to read. A surface missing any of the three cannot be checked.
+
+## Content classes and their single home
+
+Ask one question of every proposition:
+
+> Does acting on the code require this fact, or does understanding the module require it?
+
+| Class | Home | Form |
+|---|---|---|
+| Conceptual model, design rationale, the why | `README.md` | prose |
+| Module orientation, onboarding | `README.md` | prose |
+| Symbol index: class, role, path | `AGENTS.md` | terse bullet |
+| Invariants, constraints, gotchas that change how you edit | `AGENTS.md` | imperative single statement |
+| Subject-to-file routing | `AGENTS.md` `## Navigation`, `README.md` index rows | link rows |
+| Configuration reference: YAML schemas, endpoint contracts, request and response shapes, worked examples | `docs/*.md` | reference prose plus code blocks |
+| Local implementation detail tied to one call site | code comment | inline |
+| Multi-step cross-cutting procedure | a skill | not a documentation surface |
+
+A proposition belonging to two classes is split, never restated in two registers. The why goes to `README.md`, the what and where to `AGENTS.md`, the schema to `docs/`. Cross-link the halves.
+
+## What must never appear twice
+
+- **The enumerated symbol inventory.** It lives in `AGENTS.md` only. A `README.md` names a class inside a sentence of explanation and carries no class list.
+- **Invariants.** Each lives in `AGENTS.md` only. A `README.md` describes the concept an invariant protects and never restates the rule.
+- **Commands and conventions.** Stated once.
+
+## What appears nowhere
+
+Generic language, framework, and tooling knowledge. A model already has it, and repeating it costs context that the project's own machinery needs.
+
+The project's non-standard machinery is the opposite case and gets documented deliberately: the conventions it invented, the framework defaults it overrides, the pattern a reader would otherwise assume is the standard one.
+
+## `AGENTS.md` bullet discipline
+
+One bullet names a symbol, its role, and its path, plus at most one invariant. A bullet that runs past a couple of sentences is a narrative, and a narrative belongs in the owning `README.md` or a `docs/` file.
+
+`AGENTS.md` is inlined into every session that touches the directory. A bullet of 2,000 characters there costs more than the same prose in a `docs/` file that gets read when it is needed.
+
+Each `AGENTS.md` carries a `## Navigation` section mapping the area's subjects to the files that own them.
+
+## Subject ownership
+
+One directory owns a subject. Its `README.md` explains it, its `AGENTS.md` indexes the code, its `docs/` holds the reference material. The directory that owns the code owns its documentation.
+
+A project may supply its own ownership table, mapping each directory to the subject it owns; use that table where it exists. A surface with a budget but no stated owner cannot be checked for single ownership.
+
+A subject documented in two directories has one of them wrong. Pick the owner, move the prose, and leave a link.
+
+## Naming inside `docs/`
+
+- An extension guide is `custom-<subject>.md`, so the set is findable from filenames alone.
+- An introspection endpoint contract is `introspection.md`, in the directory that owns the registry it exposes.
+- A per-item reference file is named for the item's identifier, not its class: `csv_export.md`, not `CsvExportHandler.md`.
+- A worked example is `<subject>-example.md` or `worked-example.md`.
+
+## Adding a surface
+
+When the project supplies an ownership table, a file inside the measured scope but absent from it gets its row added in the same change. Without a stated owner there is nothing for the single-owner check to test.

--- a/plugins/shopware-documentation/skills/structuring-documentation/scripts/measure.sh
+++ b/plugins/shopware-documentation/skills/structuring-documentation/scripts/measure.sh
@@ -59,8 +59,9 @@ function heading_slug(line,   n, t) {
     while (substr(line, n + 1, 1) == "#") { n = n + 1 }
     if (n > 6) { return "" }
     t = substr(line, n + 1)
-    sub(/^[ \t]+/, "", t)
+    sub(/[ \t]+$/, "", t)
     sub(/#+$/, "", t)
+    sub(/^[ \t]+/, "", t)
     sub(/[ \t]+$/, "", t)
     HEAD_OK = 1
     return slug(t)
@@ -127,10 +128,15 @@ function is_routing_row(line,   prose, hits) {
 
 # shellcheck disable=SC2016  # awk source: $0 and backticks are awk syntax
 AWK_SIZE='
-function scan_markers(   rest, c) {
+function scan_markers(   rest, c, term_pos, consumer) {
     if (!exempt && match($0, /<!--[ \t]*size-exempt:[ \t]*/)) {
         rest = substr($0, RSTART + RLENGTH)
-        if (index(rest, "-->") > 0) { exempt = 1 }
+        term_pos = index(rest, "-->")
+        if (term_pos > 0) {
+            consumer = substr(rest, 1, term_pos - 1)
+            sub(/[ \t]+$/, "", consumer)
+            if (consumer != "") { exempt = 1 }
+        }
     }
     if (crit == "" && match($0, /<!--[ \t]*size-allowance:[ \t]*/)) {
         rest = substr($0, RSTART + RLENGTH)
@@ -143,9 +149,9 @@ function scan_markers(   rest, c) {
 }
 BEGIN { fenced = 0; rows = 0; delta = 0; exempt = 0; crit = "" }
 {
-    scan_markers()
     if ($0 ~ /^[ \t]*```/) { fenced = 1 - fenced; next }
     if (fenced) { next }
+    scan_markers()
     if (is_routing_row($0)) {
         rows = rows + 1
         delta = delta + length($0) + 1

--- a/plugins/shopware-documentation/skills/structuring-documentation/scripts/measure.sh
+++ b/plugins/shopware-documentation/skills/structuring-documentation/scripts/measure.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+# Measure Markdown documentation surfaces against size budgets and
+# cross-reference rules. Reports only; never modifies a file.
+set -euo pipefail
+
+# Byte-deterministic awk: length() and character classes are locale-dependent,
+# and raw sizes are measured in bytes (wc -c), so awk must count bytes too.
+export LC_ALL=C
+
+TAB=$'\t'
+
+MODE=''
+STRICT=0
+GOAL=5000
+LIMIT=6500
+CEILING=10000
+MAX_INDEX_ROWS=20
+RUN_TMP=''
+TOTAL_FINDINGS=0
+ANCHOR_CACHE_KEY=''
+
+usage() {
+    printf '%s\n' \
+        'usage: measure.sh <mode> [flags] PATH [PATH ...]' \
+        '  mode    size | links | all' \
+        '  flags   --strict --goal N --limit N --ceiling N --max-index-rows N' >&2
+    exit 2
+}
+
+# shellcheck disable=SC2329  # invoked from the EXIT trap set in main
+cleanup() {
+    if [[ -n "${RUN_TMP}" ]] && [[ -d "${RUN_TMP}" ]]; then
+        rm -rf -- "${RUN_TMP}"
+    fi
+}
+
+# --- shared awk helpers -----------------------------------------------------
+#
+# Portable awk only: no gensub, no capture-group array from match(), no
+# regex intervals. Sub-expressions are recovered with index()/substr().
+
+AWK_LIB='
+function slug(text,   t) {
+    t = text
+    gsub(/`/, "", t)
+    sub(/^[ \t]+/, "", t)
+    sub(/[ \t]+$/, "", t)
+    t = tolower(t)
+    gsub(/[^a-z0-9_ \t-]/, "", t)
+    gsub(/[ \t]+/, "-", t)
+    return t
+}
+
+# Sets HEAD_OK to 1 and returns the anchor slug when line is an ATX heading.
+function heading_slug(line,   n, t) {
+    HEAD_OK = 0
+    if (line !~ /^#+[ \t]/) { return "" }
+    n = 0
+    while (substr(line, n + 1, 1) == "#") { n = n + 1 }
+    if (n > 6) { return "" }
+    t = substr(line, n + 1)
+    sub(/^[ \t]+/, "", t)
+    sub(/#+$/, "", t)
+    sub(/[ \t]+$/, "", t)
+    HEAD_OK = 1
+    return slug(t)
+}
+
+# Finds the first Markdown link in s at or after position from.
+# Sets G_START, G_LEN, G_TARGET, G_ANCHOR. Returns 1 when one was found.
+function find_link(s, from,   rest, inner, p, hashpos) {
+    G_START = 0
+    G_LEN = 0
+    G_TARGET = ""
+    G_ANCHOR = ""
+    rest = substr(s, from)
+    if (match(rest, /\[[^]]*\]\([ \t]*[^) \t#]*(#[^) \t]*)?[ \t]*\)/) == 0) { return 0 }
+    G_START = from + RSTART - 1
+    G_LEN = RLENGTH
+    inner = substr(rest, RSTART, RLENGTH)
+    p = index(inner, "](")
+    inner = substr(inner, p + 2, length(inner) - p - 2)
+    sub(/^[ \t]+/, "", inner)
+    sub(/[ \t]+$/, "", inner)
+    hashpos = index(inner, "#")
+    if (hashpos > 0) {
+        G_TARGET = substr(inner, 1, hashpos - 1)
+        G_ANCHOR = substr(inner, hashpos + 1)
+    } else {
+        G_TARGET = inner
+    }
+    return 1
+}
+
+function strip_links(s,   out, pos) {
+    out = ""
+    pos = 1
+    while (pos <= length(s) && find_link(s, pos)) {
+        out = out substr(s, pos, G_START - pos)
+        pos = G_START + G_LEN
+    }
+    return out substr(s, pos)
+}
+
+function has_md_link(line,   pos) {
+    pos = 1
+    while (pos <= length(line) && find_link(line, pos)) {
+        if (G_TARGET ~ /\.md$/) { return 1 }
+        pos = G_START + G_LEN
+    }
+    return 0
+}
+
+# A list item or table row carrying one Markdown link plus at most one sentence.
+function is_routing_row(line,   prose, hits) {
+    if (line !~ /^[ \t]*([-*+][ \t]+|[0-9]+\.[ \t]+|\|)/) { return 0 }
+    if (!has_md_link(line)) { return 0 }
+    prose = strip_links(line)
+    gsub(/[-|*+`]/, " ", prose)
+    sub(/^[ \t]+/, "", prose)
+    sub(/[ \t]+$/, "", prose)
+    prose = prose " "
+    hits = gsub(/[.!?][ \t]/, "", prose)
+    return (hits <= 1)
+}
+'
+
+# shellcheck disable=SC2016  # awk source: $0 and backticks are awk syntax
+AWK_SIZE='
+function scan_markers(   rest, c) {
+    if (!exempt && match($0, /<!--[ \t]*size-exempt:[ \t]*/)) {
+        rest = substr($0, RSTART + RLENGTH)
+        if (index(rest, "-->") > 0) { exempt = 1 }
+    }
+    if (crit == "" && match($0, /<!--[ \t]*size-allowance:[ \t]*/)) {
+        rest = substr($0, RSTART + RLENGTH)
+        c = ""
+        if (rest ~ /^lookup([^a-zA-Z0-9_]|$)/) { c = "lookup" }
+        else if (rest ~ /^contiguous([^a-zA-Z0-9_]|$)/) { c = "contiguous" }
+        else if (rest ~ /^atomic([^a-zA-Z0-9_]|$)/) { c = "atomic" }
+        if (c != "" && index(substr(rest, length(c) + 1), "-->") > 0) { crit = c }
+    }
+}
+BEGIN { fenced = 0; rows = 0; delta = 0; exempt = 0; crit = "" }
+{
+    scan_markers()
+    if ($0 ~ /^[ \t]*```/) { fenced = 1 - fenced; next }
+    if (fenced) { next }
+    if (is_routing_row($0)) {
+        rows = rows + 1
+        delta = delta + length($0) + 1
+    }
+}
+END { printf "%d %d %d %s\n", rows, delta, exempt, crit }
+'
+
+# shellcheck disable=SC2016  # awk source: $0 and backticks are awk syntax
+AWK_LINKS='
+function scan_bare(s, lineno,   pos, rest, span, bare) {
+    pos = 1
+    while (pos <= length(s)) {
+        rest = substr(s, pos)
+        if (match(rest, /`[^`]*\.md`/) == 0) { return }
+        span = substr(rest, RSTART, RLENGTH)
+        bare = substr(span, 2, length(span) - 2)
+        pos = pos + RSTART + RLENGTH - 1
+        if (bare ~ /[<>*{}]/ || bare ~ /[ \t]/) { continue }
+        printf "B\t%d\t%s\t\n", lineno, bare
+    }
+}
+BEGIN { fenced = 0 }
+{
+    if ($0 ~ /^[ \t]*```/) { fenced = 1 - fenced; next }
+    if (fenced) { next }
+    pos = 1
+    while (pos <= length($0) && find_link($0, pos)) {
+        pos = G_START + G_LEN
+        if (G_TARGET ~ /^https?:\/\//) { continue }
+        if (G_TARGET ~ /^mailto:/) { continue }
+        if (G_TARGET != "" && G_TARGET !~ /\.md$/) { continue }
+        printf "L\t%d\t%s\t%s\n", NR, G_TARGET, G_ANCHOR
+    }
+    scan_bare(strip_links($0), NR)
+}
+'
+
+# shellcheck disable=SC2016  # awk source: $0 is an awk field reference
+AWK_ANCHORS='
+BEGIN { fenced = 0 }
+{
+    if ($0 ~ /^[ \t]*```/) { fenced = 1 - fenced; next }
+    if (fenced) { next }
+    found = heading_slug($0)
+    if (HEAD_OK) { print found }
+}
+'
+
+# shellcheck disable=SC2016  # awk source: $0 is an awk field reference
+AWK_SLUG='
+{ print slug($0) }
+'
+
+# --- argument parsing -------------------------------------------------------
+
+require_number() {
+    case "${1:-}" in
+        '' | *[!0-9]*) usage ;;
+    esac
+}
+
+parse_args() {
+    [[ "$#" -ge 1 ]] || usage
+    MODE="$1"
+    shift
+    case "${MODE}" in
+        size | links | all) ;;
+        *) usage ;;
+    esac
+
+    local paths
+    paths=()
+    while [[ "$#" -gt 0 ]]; do
+        case "$1" in
+            --strict)
+                STRICT=1
+                shift
+                ;;
+            --goal)
+                shift
+                require_number "${1:-}"
+                GOAL=$((10#$1))
+                shift
+                ;;
+            --limit)
+                shift
+                require_number "${1:-}"
+                LIMIT=$((10#$1))
+                shift
+                ;;
+            --ceiling)
+                shift
+                require_number "${1:-}"
+                CEILING=$((10#$1))
+                shift
+                ;;
+            --max-index-rows)
+                shift
+                require_number "${1:-}"
+                MAX_INDEX_ROWS=$((10#$1))
+                shift
+                ;;
+            --)
+                shift
+                while [[ "$#" -gt 0 ]]; do
+                    paths+=("$1")
+                    shift
+                done
+                ;;
+            -*)
+                usage
+                ;;
+            *)
+                paths+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    [[ "${#paths[@]}" -gt 0 ]] || usage
+
+    local missing
+    missing=''
+    local candidate
+    for candidate in "${paths[@]}"; do
+        if [[ ! -e "${candidate}" ]]; then
+            if [[ -n "${missing}" ]]; then
+                missing="${missing}, ${candidate}"
+            else
+                missing="${candidate}"
+            fi
+        fi
+    done
+    if [[ -n "${missing}" ]]; then
+        printf 'path does not exist: %s\n' "${missing}" >&2
+        exit 2
+    fi
+
+    for candidate in "${paths[@]}"; do
+        if [[ -f "${candidate}" ]]; then
+            case "${candidate}" in
+                *.md) printf '%s\n' "${candidate}" >> "${RUN_TMP}/scope" ;;
+            esac
+        else
+            local scan_root="${candidate}"
+            case "${scan_root}" in
+                -*) scan_root="./${scan_root}" ;;
+            esac
+            find "${scan_root}" -type f -name '*.md' | LC_ALL=C sort >> "${RUN_TMP}/scope"
+        fi
+    done
+}
+
+# --- size mode --------------------------------------------------------------
+
+size_mode() {
+    local rows_file="${RUN_TMP}/size_rows"
+    local findings_file="${RUN_TMP}/size_findings"
+    local order_file="${RUN_TMP}/size_order"
+    : > "${rows_file}"
+    : > "${findings_file}"
+
+    local index=0
+    local surfaces=0
+    local file
+    while IFS= read -r file; do
+        index=$((index + 1))
+        surfaces=$((surfaces + 1))
+
+        local raw
+        raw="$(wc -c < "${file}" | tr -d ' ')"
+
+        local parsed
+        parsed="$(awk "${AWK_LIB}${AWK_SIZE}" < "${file}")"
+        local rows delta exempt criterion
+        # criterion is last so an empty value cannot swallow another field.
+        read -r rows delta exempt criterion <<< "${parsed}"
+        criterion="${criterion:-}"
+
+        local base
+        base="$(basename -- "${file}")"
+        local counted
+        if [[ "${base}" == 'AGENTS.md' ]] || [[ "${base}" == 'CLAUDE.md' ]]; then
+            counted="${raw}"
+        else
+            counted=$((raw - delta))
+        fi
+
+        local verdict
+        local finding_seq=0
+        if [[ "${exempt}" -eq 1 ]]; then
+            verdict='exempt'
+            # An allowance criterion, when the file also carries one, outranks
+            # the bare `parsed` marker of an exemption.
+            if [[ -z "${criterion}" ]]; then
+                criterion='parsed'
+            fi
+        elif [[ "${counted}" -le "${GOAL}" ]]; then
+            verdict='goal'
+        elif [[ "${counted}" -le "${LIMIT}" ]]; then
+            verdict='allowed'
+        elif [[ "${counted}" -le "${CEILING}" ]]; then
+            verdict='allowance'
+            if [[ -z "${criterion}" ]]; then
+                finding_seq=$((finding_seq + 1))
+                printf '%s\t%s\t%s\t%s chars above the %s limit with no allowance marker\n' \
+                    "${index}" "${finding_seq}" "${file}" "${counted}" "${LIMIT}" >> "${findings_file}"
+            fi
+        else
+            verdict='over'
+            finding_seq=$((finding_seq + 1))
+            printf '%s\t%s\t%s\t%s chars above the %s ceiling; splits regardless of any marker\n' \
+                "${index}" "${finding_seq}" "${file}" "${counted}" "${CEILING}" >> "${findings_file}"
+        fi
+
+        if [[ "${rows}" -gt "${MAX_INDEX_ROWS}" ]]; then
+            finding_seq=$((finding_seq + 1))
+            printf '%s\t%s\t%s\t%s routing rows above the %s maximum\n' \
+                "${index}" "${finding_seq}" "${file}" "${rows}" "${MAX_INDEX_ROWS}" >> "${findings_file}"
+        fi
+
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "${counted}" "${index}" "${raw}" "${rows}" "${verdict}" "${criterion}" "${file}" >> "${rows_file}"
+    done < "${RUN_TMP}/scope"
+
+    printf '%8s %8s %5s  %-10s %-11s %s\n' 'counted' 'raw' 'rows' 'verdict' 'criterion' 'path'
+    sort -t"${TAB}" -k1,1nr -k2,2n "${rows_file}" > "${order_file}"
+    awk -F'\t' '{ printf "%8s %8s %5s  %-10s %-11s %s\n", $1, $3, $4, $5, $6, $7 }' "${order_file}"
+
+    local finding_count
+    finding_count="$(wc -l < "${findings_file}" | tr -d ' ')"
+
+    local plural='s'
+    if [[ "${surfaces}" -eq 1 ]]; then
+        plural=''
+    fi
+    printf '\n%s surface%s measured, %s findings\n' "${surfaces}" "${plural}" "${finding_count}"
+
+    if [[ -s "${findings_file}" ]]; then
+        cut -d"${TAB}" -f2 "${order_file}" > "${RUN_TMP}/size_rank"
+        awk -F'\t' 'NR == FNR { rank[$1] = FNR; next } { print rank[$1] "\t" $2 "\t" $3 "\t" $4 }' \
+            "${RUN_TMP}/size_rank" "${findings_file}" \
+            | sort -t"${TAB}" -k1,1n -k2,2n \
+            | awk -F'\t' '{ printf "  %s: %s\n", $3, $4 }'
+    fi
+
+    TOTAL_FINDINGS=$((TOTAL_FINDINGS + finding_count))
+}
+
+# --- links mode -------------------------------------------------------------
+
+load_anchors() {
+    local destination="$1"
+    if [[ "${destination}" == "${ANCHOR_CACHE_KEY}" ]]; then
+        return 0
+    fi
+    awk "${AWK_LIB}${AWK_ANCHORS}" < "${destination}" > "${RUN_TMP}/anchors"
+    ANCHOR_CACHE_KEY="${destination}"
+}
+
+slug_of() {
+    printf '%s\n' "$1" | awk "${AWK_LIB}${AWK_SLUG}"
+}
+
+links_mode() {
+    local findings_file="${RUN_TMP}/link_findings"
+    : > "${findings_file}"
+    local scanned=0
+    local seen=0
+    local resolved=0
+
+    local file
+    while IFS= read -r file; do
+        scanned=$((scanned + 1))
+        local dir
+        dir="$(dirname -- "${file}")"
+
+        awk "${AWK_LIB}${AWK_LINKS}" < "${file}" > "${RUN_TMP}/link_records"
+
+        local record kind lineno first second rest
+        # Split on tabs by hand: a tab is IFS whitespace, so `read` would
+        # collapse the empty target of a same-file anchor into its neighbour.
+        while IFS= read -r record; do
+            kind="${record%%"${TAB}"*}"
+            rest="${record#*"${TAB}"}"
+            lineno="${rest%%"${TAB}"*}"
+            rest="${rest#*"${TAB}"}"
+            first="${rest%%"${TAB}"*}"
+            second="${rest#*"${TAB}"}"
+
+            if [[ "${kind}" == 'B' ]]; then
+                local where='DOES NOT RESOLVE'
+                if [[ -f "${dir}/${first}" ]]; then
+                    where='resolves'
+                fi
+                # shellcheck disable=SC2016  # the backticks are literal report text
+                printf '  %s:%s: bare path is not a cross-reference (%s): `%s`\n' \
+                    "${file}" "${lineno}" "${where}" "${first}" >> "${findings_file}"
+                continue
+            fi
+
+            seen=$((seen + 1))
+            local destination
+            if [[ -z "${first}" ]]; then
+                destination="${file}"
+            else
+                destination="${dir}/${first}"
+            fi
+            if [[ ! -f "${destination}" ]]; then
+                printf '  %s:%s: link target does not exist: %s\n' \
+                    "${file}" "${lineno}" "${first}" >> "${findings_file}"
+                continue
+            fi
+            resolved=$((resolved + 1))
+
+            if [[ -z "${second}" ]]; then
+                continue
+            fi
+            load_anchors "${destination}"
+            if ! grep -qxF -- "${second}" "${RUN_TMP}/anchors"; then
+                printf '  %s:%s: anchor not found in %s: #%s\n' \
+                    "${file}" "${lineno}" "${first}" "${second}" >> "${findings_file}"
+                continue
+            fi
+            if [[ -z "${first}" ]]; then
+                continue
+            fi
+            local stem
+            stem="$(basename -- "${destination}")"
+            stem="${stem%.md}"
+            stem="${stem//-/ }"
+            local stem_slug
+            stem_slug="$(slug_of "${stem}")"
+            if [[ "${second}" == "${stem_slug}" ]]; then
+                printf '  %s:%s: anchor restates the target file: #%s\n' \
+                    "${file}" "${lineno}" "${second}" >> "${findings_file}"
+            fi
+        done < "${RUN_TMP}/link_records"
+    done < "${RUN_TMP}/scope"
+
+    # Known-positive guard: zero citations seen means the sweep itself is broken,
+    # which no clean tree can be distinguished from.
+    if [[ "${seen}" -eq 0 ]]; then
+        printf 'FIXTURE FAILURE: no citation matched anywhere in scope\n' >&2
+        printf '  .:0: sweep matched nothing; the check itself is broken\n'
+        TOTAL_FINDINGS=$((TOTAL_FINDINGS + 1))
+        return 0
+    fi
+
+    local finding_count
+    finding_count="$(wc -l < "${findings_file}" | tr -d ' ')"
+    printf '%s files scanned, %s citations found, %s resolved, %s findings\n' \
+        "${scanned}" "${seen}" "${resolved}" "${finding_count}"
+    if [[ -s "${findings_file}" ]]; then
+        cat "${findings_file}"
+    fi
+
+    TOTAL_FINDINGS=$((TOTAL_FINDINGS + finding_count))
+}
+
+# --- entry point ------------------------------------------------------------
+
+main() {
+    trap cleanup EXIT
+    RUN_TMP="$(mktemp -d "${TMPDIR:-/tmp}/measure-sh.XXXXXX")"
+    : > "${RUN_TMP}/scope"
+
+    parse_args "$@"
+
+    case "${MODE}" in
+        size)
+            size_mode
+            ;;
+        links)
+            links_mode
+            ;;
+        all)
+            size_mode
+            printf '\n'
+            links_mode
+            ;;
+    esac
+
+    if [[ "${STRICT}" -eq 1 ]] && [[ "${TOTAL_FINDINGS}" -gt 0 ]]; then
+        exit 1
+    fi
+    exit 0
+}
+
+main "$@"


### PR DESCRIPTION
Adds the `shopware-documentation` plugin: one skill, `structuring-documentation`, that keeps a repository's Markdown documentation surfaces (README.md, AGENTS.md, CLAUDE.md, and `docs/` siblings) inside size budgets, holding one subject per file, with cross-references that resolve. Oversized multi-subject files are expensive to read whole and their sections cannot be addressed by navigation, so the skill measures the surfaces in scope, splits what is too large, places each subject with the directory that owns it, and repairs citations.

### The skill

Scope is supplied per invocation. The surfaces are the paths the user names or the documentation files the current change touches, the script has no default scope, and the skill asks when no scope is stated. Budgets are named values with inline defaults, overridable from context or user instruction and passed to the script as flags:

| Named value           | Default | Flag               |
|-----------------------|---------|--------------------|
| `docs.size_goal`      | 5,000   | `--goal`           |
| `docs.size_limit`     | 6,500   | `--limit`          |
| `docs.size_ceiling`   | 10,000  | `--ceiling`        |
| `docs.max_index_rows` | 20      | `--max-index-rows` |

A project can supply its own subject-ownership table as extension content, and the workflow consults it wherever ownership matters. The workflow digraph covers the full loop: measurement, a one-subject-per-file and ownership check with a rehome path, budget verdicts and allowance criteria (`lookup`, `contiguous`, `atomic`, plus `size-exempt` for machine-parsed surfaces), citation repair for bare paths, dead targets, and stale anchors, the post-move sweeps, and a resolved-or-dismissed exit so findings the rules themselves exempt dismiss with a stated reason instead of blocking convergence. Two reference files carry the content-class contract (which file owns which kind of fact) and the splitting procedure with its four post-split defect classes.

### The measurement script

`scripts/measure.sh` has three modes. `size` reports counted bytes (routing rows excluded), raw bytes, routing rows, and a budget verdict per surface. Allowance and exemption markers are recognized on non-fenced lines only, so a fenced documentation example of a marker grants nothing. `links` resolves every relative Markdown cross-reference and anchor from the citing file's position using GitHub-style ASCII slugs, flags backticked bare `.md` paths, and carries a known-positive fixture that fails loudly when the sweep matches nothing. `all` runs both. The script is bash 3.2 compatible across BSD and GNU userlands, with no dependencies beyond POSIX utilities plus awk and mktemp, because this marketplace's BATS harness only tests real bash. 95 BATS tests under `plugin-tests/shopware-documentation/` pin the behavior byte-for-byte, down to column widths, exit codes, and finding order.