### PR TITLE
feat(dev-tooling): add console_run output_file and arbitrary envs

### DIFF
--- a/plugin-tests/dev-tooling/mcp_tool_console.bats
+++ b/plugin-tests/dev-tooling/mcp_tool_console.bats
@@ -11,7 +11,29 @@ setup() {
 }
 
 teardown() {
-    unset LINT_ENV LINT_WORKDIR LINT_CONFIG_FILE
+    unset LINT_ENV LINT_WORKDIR LINT_CONFIG_FILE CONSOLE_FAKE_CMD
+}
+
+# Replace the wrapped invocation with a controlled shell snippet, so the
+# file-capture path runs a real command instead of the absent bin/console.
+_stub_wrapped_command() {
+    CONSOLE_FAKE_CMD="$1"
+    wrap_command() { printf '%s\n' "${CONSOLE_FAKE_CMD}"; }
+}
+
+# Make the wrapped invocation print the command it was handed, so the captured
+# file holds the constructed bin/console line.
+_echo_wrapped_command() {
+    wrap_command() { printf 'printf %%s %s\n' "$(printf '%q' "$1")"; }
+}
+
+# Put one argument set through the vendored MCP validator against the real
+# tools.json, the way the server does before it dispatches a tool.
+_validate_console_run() {
+    MCP_TOOLS_LIST_FILE="${PLUGIN_DIR}/mcp-server-php/tools.json"
+    # shellcheck source=/dev/null  # sourced for validate_tool_arguments only
+    source "${PLUGIN_DIR}/shared/mcpserver_core.sh"
+    validate_tool_arguments "console_run" "$1"
 }
 
 # --- Basic command construction ---
@@ -58,6 +80,51 @@ teardown() {
     run tool_console_run '{"command":"cache:clear","env":"prod"}'
     assert_success
     assert_output --partial '--env="prod"'
+}
+
+@test "console: env value outside the old enum adds --env flag" {
+    run tool_console_run '{"command":"cache:clear","env":"staging"}'
+    assert_success
+    assert_output --partial '--env="staging"'
+}
+
+@test "console: env absent emits no --env flag" {
+    run tool_console_run '{"command":"cache:clear"}'
+    assert_success
+    refute_output --partial '--env'
+}
+
+@test "console: configured .console.env default applies when env is absent" {
+    printf '%s\n' '{"environment":"native","console":{"env":"staging"}}' > "${LINT_CONFIG_FILE}"
+    run tool_console_run '{"command":"cache:clear"}'
+    assert_success
+    assert_output --partial '--env="staging"'
+}
+
+@test "console schema: validation accepts an env name outside the old enum" {
+    run _validate_console_run '{"command":"cache:clear","env":"staging"}'
+    assert_success
+    assert_output ""
+}
+
+@test "console schema: validation rejects an env value carrying a shell metacharacter" {
+    run _validate_console_run '{"command":"cache:clear","env":"prod; rm -rf /"}'
+    assert_failure
+    assert_output --partial "env"
+    assert_output --partial "pattern"
+}
+
+@test "console schema: validation rejects an env value longer than 32 characters" {
+    run _validate_console_run "{\"command\":\"cache:clear\",\"env\":\"$(printf 'e%.0s' {1..33})\"}"
+    assert_failure
+    assert_output --partial "env"
+    assert_output --partial "pattern"
+}
+
+@test "console schema: validation accepts an output_file string" {
+    run _validate_console_run '{"command":"cache:clear","output_file":"var/dump.txt"}'
+    assert_success
+    assert_output ""
 }
 
 @test "console: verbosity quiet adds -q" {
@@ -161,6 +228,162 @@ bats_test_function --description "console: option name containing a line break i
     run tool_console_run '{not valid json'
     assert_failure
     assert_output --partial "Refusing to run: could not parse arguments as JSON"
+}
+
+# --- output_file: stdout captured to a file ---
+
+@test "console: output_file receives the command's stdout verbatim" {
+    _stub_wrapped_command 'printf "line one\nline two\n"'
+    local target="${BATS_TEST_TMPDIR}/cap/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_success
+    run cat "${target}"
+    assert_output $'line one\nline two'
+}
+
+@test "console: output_file response carries the summary and not the payload" {
+    _stub_wrapped_command 'printf "PAYLOAD-MARKER\n"'
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_success
+    assert_output --partial "Wrote stdout to ${target}"
+    assert_output --partial "Bytes written: 15"
+    assert_output --partial "Exit status: 0"
+    refute_output --partial "PAYLOAD-MARKER"
+}
+
+@test "console: output_file keeps stderr in the response" {
+    _stub_wrapped_command 'printf "payload\n"; printf "a warning\n" >&2'
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_success
+    assert_output --partial "a warning"
+}
+
+@test "console: output_file applies the noise filter to stderr" {
+    _stub_wrapped_command 'printf "payload\n"; printf "Xdebug: [Step Debug] Could not connect to debugging client.\nreal warning\n" >&2'
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_success
+    assert_output --partial "real warning"
+    refute_output --partial "Step Debug"
+}
+
+@test "console: an existing regular output_file is overwritten on success" {
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    printf 'earlier run\n' > "${target}"
+    _stub_wrapped_command 'printf "fresh\n"'
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_success
+    run cat "${target}"
+    assert_output "fresh"
+}
+
+@test "console: a failed command leaves a pre-existing output_file untouched" {
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    printf 'earlier run\n' > "${target}"
+    _stub_wrapped_command 'printf "partial\n"; exit 3'
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_failure 3
+    run cat "${target}"
+    assert_output "earlier run"
+}
+
+@test "console: a failed command leaves no temporary file beside the target" {
+    local dir="${BATS_TEST_TMPDIR}/cap"
+    mkdir -p "${dir}"
+    printf 'earlier run\n' > "${dir}/dump.txt"
+    _stub_wrapped_command 'printf "partial\n"; exit 3'
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${dir}/dump.txt\"}"
+    assert_failure 3
+    run ls "${dir}"
+    assert_output "dump.txt"
+}
+
+@test "console: a failed command returns its stdout in the response" {
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    _stub_wrapped_command 'printf "diagnostic line\n"; exit 4'
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_failure 4
+    assert_output --partial "diagnostic line"
+    assert_output --partial "was not written"
+}
+
+@test "console: a failed command keeps stdout and stderr on separate lines" {
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    _stub_wrapped_command 'printf "no trailing newline"; printf "stderr line\n" >&2; exit 6'
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_failure 6
+    assert_line "no trailing newline"
+    assert_line "stderr line"
+}
+
+@test "console: output_file pointing at a symlink is refused" {
+    local target="${BATS_TEST_TMPDIR}/link.txt"
+    ln -s "${BATS_TEST_TMPDIR}/elsewhere.txt" "${target}"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_failure
+    assert_output --partial "\"${target}\" exists as a symbolic link"
+}
+
+@test "console: output_file pointing at a directory is refused" {
+    local target="${BATS_TEST_TMPDIR}/adir"
+    mkdir -p "${target}"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${target}\"}"
+    assert_failure
+    assert_output --partial "\"${target}\" exists as a directory"
+}
+
+@test "console: a relative output_file resolves against the working directory" {
+    cd "${BATS_TEST_TMPDIR}"
+    _stub_wrapped_command 'printf "ok\n"'
+    run tool_console_run '{"command":"debug:container","output_file":"nested/dump.txt"}'
+    assert_success
+    assert_output --partial "Wrote stdout to ${BATS_TEST_TMPDIR}/nested/dump.txt"
+    run cat "${BATS_TEST_TMPDIR}/nested/dump.txt"
+    assert_output "ok"
+}
+
+@test "console: an output_file beginning with a dash is pinned to the working directory" {
+    cd "${BATS_TEST_TMPDIR}"
+    _stub_wrapped_command 'printf "ok\n"'
+    run tool_console_run '{"command":"debug:container","output_file":"-dash.txt"}'
+    assert_success
+    assert_output --partial "Wrote stdout to ${BATS_TEST_TMPDIR}/./-dash.txt"
+    run cat -- "${BATS_TEST_TMPDIR}/-dash.txt"
+    assert_output "ok"
+}
+
+@test "console: an output_file longer than 4096 bytes is refused" {
+    local long
+    long="${BATS_TEST_TMPDIR}/$(printf 'a%.0s' {1..4097})"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${long}\"}"
+    assert_failure
+    assert_output --partial '"output_file" is longer than 4096 bytes'
+}
+
+@test "console: an output_file at exactly 4096 bytes passes the length cap" {
+    # No host can create a 4096-byte path, so only the cap's boundary is
+    # asserted here: this value must not be the one the cap rejects.
+    local at_cap
+    at_cap="${BATS_TEST_TMPDIR}/$(printf 'a%.0s' $(seq 1 $(( 4095 - ${#BATS_TEST_TMPDIR} ))))"
+    run tool_console_run "{\"command\":\"debug:container\",\"output_file\":\"${at_cap}\"}"
+    refute_output --partial "is longer than 4096 bytes"
+}
+
+@test "console: an empty output_file behaves as an absent parameter" {
+    run tool_console_run '{"command":"cache:clear","output_file":""}'
+    assert_success
+    assert_output 'bin/console "cache:clear"'
+}
+
+@test "console: env and output_file compose in one call" {
+    _echo_wrapped_command
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"env\":\"staging\",\"output_file\":\"${target}\"}"
+    assert_success
+    run cat "${target}"
+    assert_output --partial '--env="staging"'
 }
 
 # --- Console list ---

--- a/plugins/dev-tooling/.claude-plugin/plugin.json
+++ b/plugins/dev-tooling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tooling",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Three MCP servers for PHP and JavaScript operations plus an optional PHP language server. PHP (php-tooling): PHPStan, ECS, Rector, PHPUnit, PHPUnit coverage gap analysis, Symfony Console. Administration (js-admin-tooling): ESLint, Stylelint, Prettier, Jest, TypeScript, Vite builds. Storefront (js-storefront-tooling): ESLint, Stylelint, Jest, Webpack builds. LSP (opt-in): phpactor for PHP, routed through a Python URI-rewriting proxy for containerized environments. Includes SessionStart hook that injects MCP tool directives and PreToolUse hooks that enforce MCP tool usage by blocking bash commands. Supports native, Docker, Docker Compose, Vagrant and DDEV environments.",
   "author": {
     "name": "Shopware Labs"

--- a/plugins/dev-tooling/CHANGELOG.md
+++ b/plugins/dev-tooling/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.19.0] - 2026-09-04
+
+### Added
+- **`console_run` can write the command's stdout to a file instead of the response.** A new optional `output_file` parameter captures raw stdout host-side; the response then carries a summary — resolved path, byte count, exit status — plus the noise-filtered stderr. The write is atomic (a temp sibling is renamed onto the target only after the command exits zero), a failed command leaves an existing target untouched and returns its stdout in the response as diagnostics, and a target that is a symlink or not a regular file is refused. A relative path resolves against the project root, a leading `-` is normalized with `./`, parent directories are created, and a value over 4096 bytes is refused. Calls without `output_file` behave exactly as before.
+
+### Changed
+- **`console_run`'s `env` parameter accepts any Symfony environment name.** The schema constraint widens from the `dev`/`prod`/`test` enum to the pattern `^[A-Za-z0-9_]{1,32}$`, since Symfony environments are arbitrary names (`staging`, `e2e`, …). The length bound lives inside the pattern because the vendored validator enforces `pattern` but not `maxLength`. Runtime behavior is unchanged: the value still lands as `--env=<value>`, and the `.console.env` config default still applies when the parameter is absent.
+
 ## [3.18.0] - 2026-09-03
 
 ### Changed

--- a/plugins/dev-tooling/docs/reference.md
+++ b/plugins/dev-tooling/docs/reference.md
@@ -77,6 +77,7 @@ Symfony Console. `console_run` executes a command; `console_list` returns availa
 ```
 Use console_run with command "cache:clear"
 Use console_run with command "plugin:install" arguments ["SwagPayPal"] options {"activate": true}
+Use console_run with command "debug:container" env "staging" output_file "var/dump/staging-container.txt"
 Use console_list with namespace "cache"
 ```
 
@@ -87,10 +88,13 @@ Use console_list with namespace "cache"
 | `command`        | string        | Console command (required)                     |
 | `arguments`      | array         | Positional arguments                           |
 | `options`        | object        | Options as key/value                           |
-| `env`            | string        | Symfony env (`dev`, `prod`, `test`)            |
+| `env`            | string        | Symfony env passed as `--env`. Any name the installation defines (`dev`, `prod`, `test`, `staging`, …); `^[A-Za-z0-9_]{1,32}$` |
+| `output_file`    | string        | Write stdout to this file instead of returning it (see below) |
 | `verbosity`      | string        | `quiet`, `normal`, `verbose`, `very-verbose`, `debug` |
 | `no_debug`       | boolean       | Disable debug mode                             |
 | `no_interaction` | boolean       | Non-interactive                                |
+
+With `output_file` set, stdout goes to the file and the response carries only the resolved path, the byte count and the exit status — stderr still comes back in the response. A relative path resolves against the project root, parent directories are created, and the file is replaced only after the command exits zero. A failed command leaves the target as it was and returns its stdout in the response instead. The value is refused when it is longer than 4096 bytes, or when the target already exists as a symlink or as anything other than a regular file. Omit it (or pass an empty string) to get the output in the response as before.
 
 `console_list` parameters: `namespace` (string), `format` (string).
 

--- a/plugins/dev-tooling/mcp-server-php/lib/console.sh
+++ b/plugins/dev-tooling/mcp-server-php/lib/console.sh
@@ -20,6 +20,146 @@ _refuse_linebreak_args() {
     return 0
 }
 
+# _console_resolve_output_file <value>
+# Normalize and vet the caller's "output_file" value. The length cap lives here
+# because the vendored validator enforces "pattern" but not "maxLength".
+# The value is used host-side only and never becomes part of the wrapped
+# command, so it needs no shell quoting.
+# Stdout: the resolved absolute path, or the refusal message
+# Returns: 0 when the path is usable, 1 when refused
+_console_resolve_output_file() {
+    local value="$1"
+
+    local bytes
+    bytes=$(printf '%s' "${value}" | wc -c | tr -d ' ')
+    if [[ "${bytes}" -gt 4096 ]]; then
+        printf '%s\n' "Refusing to run: \"output_file\" is longer than 4096 bytes (${bytes})."
+        return 1
+    fi
+
+    # A leading dash reads as an option to every tool that later touches the
+    # path, so it is pinned to the current directory instead.
+    case "${value}" in
+        -*) value="./${value}" ;;
+    esac
+
+    local resolved="${value}"
+    if [[ "${resolved}" != /* ]]; then
+        resolved="${PWD}/${resolved}"
+    fi
+
+    if [[ -L "${resolved}" ]]; then
+        printf '%s\n' "Refusing to run: \"output_file\" \"${resolved}\" exists as a symbolic link."
+        return 1
+    fi
+
+    if [[ -e "${resolved}" && ! -f "${resolved}" ]]; then
+        local kind="not a regular file"
+        if [[ -d "${resolved}" ]]; then
+            kind="a directory"
+        fi
+        printf '%s\n' "Refusing to run: \"output_file\" \"${resolved}\" exists as ${kind}."
+        return 1
+    fi
+
+    printf '%s\n' "${resolved}"
+}
+
+# _console_run_to_file <command> <resolved target path>
+# Run the wrapped command with stdout captured to the target file and stderr
+# kept separate, so the file holds the raw output and the response holds only a
+# summary of it. exec_command merges both streams with 2>&1, which is why this
+# path builds on wrap_command directly instead.
+# Stdout: the summary plus the filtered stderr, or the failure report
+# Returns: the command's exit status
+_console_run_to_file() {
+    local cmd="$1"
+    local target="$2"
+
+    local parent
+    parent=$(dirname -- "${target}")
+    if ! mkdir -p -- "${parent}"; then
+        printf '%s\n' "Refusing to run: could not create the parent directory of \"output_file\": ${parent}"
+        return 1
+    fi
+
+    local wrapped
+    wrapped=$(wrap_command "${cmd}") || {
+        printf '%s\n' "${wrapped}"
+        return 1
+    }
+
+    log "INFO" "Executing: ${wrapped}"
+
+    local tmp
+    if ! tmp=$(mktemp "${target}.XXXXXX"); then
+        printf '%s\n' "Refusing to run: could not create a temporary file next to \"output_file\": ${target}"
+        return 1
+    fi
+
+    local err_file
+    if ! err_file=$(mktemp); then
+        rm -f -- "${tmp}"
+        printf '%s\n' "Refusing to run: could not create a temporary file for the command's stderr."
+        return 1
+    fi
+
+    local exit_code=0
+    # The child must not inherit the server's stdin: it is the client's
+    # JSON-RPC protocol pipe, and a stdin-reading tool child would block on
+    # it forever instead of seeing EOF.
+    # The eval runs in a subshell so that an `exit` reached inside the wrapped
+    # command ends that subshell rather than the server; exec_command gets the
+    # same containment from the command substitution it assigns through.
+    ( eval "${wrapped}" ) </dev/null >"${tmp}" 2>"${err_file}" || exit_code=$?
+
+    local stderr_text
+    stderr_text=$(_filter_env_noise < "${err_file}")
+    rm -f -- "${err_file}"
+
+    log "INFO" "Command exit code: ${exit_code}"
+
+    if [[ "${exit_code}" -ne 0 ]]; then
+        # A failed command's stdout is diagnostic rather than payload, so it
+        # goes into the response and the target file stays as it was. The file
+        # is streamed rather than read into a variable, because a command
+        # substitution would drop its trailing blank lines.
+        printf '%s\n' "Command failed with exit status ${exit_code}; \"${target}\" was not written."
+        cat -- "${tmp}"
+        # Command substitution drops a trailing newline, so a non-empty result
+        # here means the captured stdout did not end in one and the stderr
+        # below would otherwise run onto its last line.
+        local last_byte
+        last_byte=$(tail -c 1 < "${tmp}")
+        rm -f -- "${tmp}"
+        if [[ -n "${last_byte}" ]]; then
+            printf '\n'
+        fi
+        if [[ -n "${stderr_text}" ]]; then
+            printf '%s\n' "${stderr_text}"
+        fi
+        return "${exit_code}"
+    fi
+
+    local bytes
+    bytes=$(wc -c < "${tmp}" | tr -d ' ')
+
+    if ! mv -- "${tmp}" "${target}"; then
+        rm -f -- "${tmp}"
+        printf '%s\n' "Command succeeded but its output could not be moved onto \"${target}\"."
+        return 1
+    fi
+
+    printf '%s\n' "Wrote stdout to ${target}"
+    printf '%s\n' "Bytes written: ${bytes}"
+    printf '%s\n' "Exit status: ${exit_code}"
+    if [[ -n "${stderr_text}" ]]; then
+        printf '%s\n' "${stderr_text}"
+    fi
+
+    return 0
+}
+
 # tool_console_run - MCP tool function
 # Args: $1 = JSON arguments
 # Returns: Console command output
@@ -49,13 +189,14 @@ tool_console_run() {
         env: (.env // null),
         verbosity: (.verbosity // null),
         no_debug: (.no_debug // null),
-        no_interaction: (.no_interaction // null)
+        no_interaction: (.no_interaction // null),
+        output_file: (.output_file // null)
     }' 2>/dev/null); then
         printf '%s\n' "Refusing to run: could not parse arguments as JSON: ${args}"
         return 1
     fi
 
-    local command arguments_json options_json env verbosity no_debug no_interaction
+    local command arguments_json options_json env verbosity no_debug no_interaction output_file
     command=$(echo "${parsed}" | jq -r '.command // empty')
     arguments_json=$(echo "${parsed}" | jq -c '.arguments')
     options_json=$(echo "${parsed}" | jq -c '.options')
@@ -63,6 +204,7 @@ tool_console_run() {
     verbosity=$(echo "${parsed}" | jq -r '.verbosity // empty')
     no_debug=$(echo "${parsed}" | jq -r '.no_debug // empty')
     no_interaction=$(echo "${parsed}" | jq -r '.no_interaction // empty')
+    output_file=$(echo "${parsed}" | jq -r '.output_file // empty')
 
     if [[ -z "${command}" ]]; then
         echo "Error: 'command' parameter is required"
@@ -97,7 +239,13 @@ tool_console_run() {
         return 1
     fi
 
-    log "INFO" "Console run: command='${command}' args='${arg_array[*]:-}' env='${env}' verbosity='${verbosity}'"
+    local resolved_output_file=""
+    if [[ -n "${output_file}" ]] && ! resolved_output_file=$(_console_resolve_output_file "${output_file}"); then
+        printf '%s\n' "${resolved_output_file}"
+        return 1
+    fi
+
+    log "INFO" "Console run: command='${command}' args='${arg_array[*]:-}' env='${env}' verbosity='${verbosity}' output_file='${resolved_output_file}'"
 
     local -a flags=()
 
@@ -166,6 +314,12 @@ tool_console_run() {
 
     local cmd="bin/console"
     [[ ${#flags[@]} -gt 0 ]] && cmd="${cmd} ${flags[*]}"
+
+    if [[ -n "${resolved_output_file}" ]]; then
+        local rc=0
+        _console_run_to_file "${cmd}" "${resolved_output_file}" || rc=$?
+        return "${rc}"
+    fi
 
     exec_command "${cmd}"
 }

--- a/plugins/dev-tooling/mcp-server-php/tools.json
+++ b/plugins/dev-tooling/mcp-server-php/tools.json
@@ -157,8 +157,12 @@
           },
           "env": {
             "type": "string",
-            "enum": ["dev", "prod", "test"],
-            "description": "Symfony environment (--env option)"
+            "pattern": "^[A-Za-z0-9_]{1,32}$",
+            "description": "Symfony environment (--env option). Any environment name the installation defines, e.g. 'dev', 'prod', 'test', 'staging'."
+          },
+          "output_file": {
+            "type": "string",
+            "description": "Write the command's stdout to this file instead of returning it. A relative path resolves against the project root; parent directories are created. The response then carries the resolved path, the byte count and the exit status, plus stderr. Refused when longer than 4096 bytes, or when the target exists as a symlink or a non-regular file. On a failed command the file is left untouched and stdout comes back in the response."
           },
           "verbosity": {
             "type": "string",


### PR DESCRIPTION
`console_run` on the `php-tooling` server gains file-captured output and loses its environment allowlist, so an env-scoped console dump — `debug:container` with `--env=test`, say — can land on disk instead of in the response. Unbounded command output stays out of the conversation entirely. `dev-tooling` goes 3.18.0 to 3.19.0.

### `output_file`

When the new optional parameter is present, the command's stdout streams host-side into a `mktemp` sibling that is renamed onto the target only after a zero exit, and the response carries a summary instead of the payload: the resolved path, the byte count, the exit status, and the noise-filtered stderr. A failed command leaves an existing target untouched and returns its stdout in the response, since a failed command's output is diagnostic rather than payload. A target that exists as a symlink or a non-regular file is refused, as is a value over 4096 bytes. A relative path resolves against the project root, a leading `-` is normalized with `./`, and parent directories are created.

The capture path builds on `wrap_command` directly rather than `exec_command`, which merges stdout and stderr with `2>&1` — the template-synced layer is untouched, and calls without `output_file` still run through `exec_command` unchanged. The eval runs in a subshell so an `exit` reached inside the wrapped command ends the capture rather than the server; reproduced without the subshell as a killed server and an orphaned temp file.

### `env`

The schema constraint widens from the `dev`/`prod`/`test` enum to `^[A-Za-z0-9_]{1,32}$`, because Symfony environments are arbitrary names. Shopware's `bin/console` reads `--env` from argv before booting the kernel, so the value selects the environment in every wrapped environment type without any `APP_ENV` handling. The length bound lives inside the pattern because the vendored validator enforces `pattern` but not `maxLength`. The runtime path is unchanged, including the `.console.env` config default.

### Limits

The console suite grows to 54 BATS tests (606 across the repository), including four that call the vendored validator directly to pin the pattern's accept and reject directions. The harness stubs execution, so only the `native` environment ran the capture path end to end; the container wrappers are asserted on their constructed command lines, and the claim that they deliver container stdout to the host is taken from their existing behavior rather than re-measured. A TOCTOU window between the symlink check and the rename remains open.