### PR TITLE
feat(dev-tooling): add console_run feature_all parameter

### DIFF
--- a/plugin-tests/dev-tooling/mcp_tool_console.bats
+++ b/plugin-tests/dev-tooling/mcp_tool_console.bats
@@ -386,6 +386,77 @@ bats_test_function --description "console: option name containing a line break i
     assert_output --partial '--env="staging"'
 }
 
+# --- feature_all: FEATURE_ALL inside the wrapped command ---
+
+# Route the constructed command through the real wrap_command from
+# shared/environment.sh, so the assertion sees the string the target
+# environment's shell finally receives rather than the unwrapped input.
+_wrap_with_real_environment() {
+    exec_command() { wrap_command "$1"; }
+}
+
+# Stand in for the docker-compose resolvers, which query a running compose
+# project at call time; _compose_wrap_command itself stays real.
+_stub_compose_resolution() {
+    source "${PLUGIN_DIR}/shared/docker-compose.sh"
+    _compose_check_prerequisites() { return 0; }
+    _compose_resolve_container() { printf '%s\n' "shop"; }
+    _compose_resolve_workdir() { printf '%s\n' "/var/www/html"; }
+}
+
+@test "console: feature_all opens the wrapped command under the native environment" {
+    _wrap_with_real_environment
+    LINT_ENV="native"
+    run tool_console_run '{"command":"cache:clear","feature_all":"major"}'
+    assert_success
+    assert_output 'FEATURE_ALL=major bin/console "cache:clear"'
+}
+
+@test "console: feature_all opens the containerized command under docker-compose" {
+    _wrap_with_real_environment
+    _stub_compose_resolution
+    LINT_ENV="docker-compose"
+    run tool_console_run '{"command":"cache:clear","feature_all":"major"}'
+    assert_success
+    assert_output --partial "bash -c 'cd /var/www/html && FEATURE_ALL=major bin/console \"cache:clear\"'"
+}
+
+@test "console: feature_all absent leaves the command free of FEATURE_ALL" {
+    _wrap_with_real_environment
+    LINT_ENV="native"
+    run tool_console_run '{"command":"cache:clear"}'
+    assert_success
+    assert_output 'bin/console "cache:clear"'
+}
+
+@test "console: feature_all value outside the enum is refused by the tool" {
+    run tool_console_run '{"command":"cache:clear","feature_all":"minor"}'
+    assert_failure
+    assert_output --partial 'Invalid feature_all value'
+}
+
+@test "console schema: validation rejects a feature_all value outside the enum" {
+    run _validate_console_run '{"command":"cache:clear","feature_all":"minor"}'
+    assert_failure
+    assert_output --partial "feature_all"
+    assert_output --partial "allowed: major, true"
+}
+
+@test "console schema: validation accepts feature_all \"major\"" {
+    run _validate_console_run '{"command":"cache:clear","feature_all":"major"}'
+    assert_success
+    assert_output ""
+}
+
+@test "console: feature_all, env and output_file compose in one call" {
+    _echo_wrapped_command
+    local target="${BATS_TEST_TMPDIR}/dump.txt"
+    run tool_console_run "{\"command\":\"debug:container\",\"feature_all\":\"major\",\"env\":\"staging\",\"output_file\":\"${target}\"}"
+    assert_success
+    run cat "${target}"
+    assert_output 'FEATURE_ALL=major bin/console "debug:container" --env="staging"'
+}
+
 # --- Console list ---
 
 @test "console list: non-llm format passes --format to bin/console" {

--- a/plugins/dev-tooling/.claude-plugin/plugin.json
+++ b/plugins/dev-tooling/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-tooling",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Three MCP servers for PHP and JavaScript operations plus an optional PHP language server. PHP (php-tooling): PHPStan, ECS, Rector, PHPUnit, PHPUnit coverage gap analysis, Symfony Console. Administration (js-admin-tooling): ESLint, Stylelint, Prettier, Jest, TypeScript, Vite builds. Storefront (js-storefront-tooling): ESLint, Stylelint, Jest, Webpack builds. LSP (opt-in): phpactor for PHP, routed through a Python URI-rewriting proxy for containerized environments. Includes SessionStart hook that injects MCP tool directives and PreToolUse hooks that enforce MCP tool usage by blocking bash commands. Supports native, Docker, Docker Compose, Vagrant and DDEV environments.",
   "author": {
     "name": "Shopware Labs"

--- a/plugins/dev-tooling/CHANGELOG.md
+++ b/plugins/dev-tooling/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.0] - 2026-09-04
+
+### Added
+- **`console_run` can set Shopware's `FEATURE_ALL` for one command.** A new optional `feature_all` parameter takes `major` or `true` and prefixes `FEATURE_ALL=<value>` onto the wrapped command, so the shell that runs it — the container's, the VM's, or the host's — puts the variable in the command's own process environment. That makes the deprecation gate `FEATURE_ALL=major bin/console cache:clear` one MCP call instead of a raw wrapper command. The two values are the whole accepted surface: the schema declares them as an enum and the tool checks them again before building the command, so no caller text ever reaches the shell here. `feature_all` combines with `env`, `output_file` and the other parameters; calls without it construct the command exactly as before.
+
 ## [3.19.0] - 2026-09-04
 
 ### Added

--- a/plugins/dev-tooling/docs/reference.md
+++ b/plugins/dev-tooling/docs/reference.md
@@ -78,6 +78,7 @@ Symfony Console. `console_run` executes a command; `console_list` returns availa
 Use console_run with command "cache:clear"
 Use console_run with command "plugin:install" arguments ["SwagPayPal"] options {"activate": true}
 Use console_run with command "debug:container" env "staging" output_file "var/dump/staging-container.txt"
+Use console_run with command "cache:clear" feature_all "major"
 Use console_list with namespace "cache"
 ```
 
@@ -90,6 +91,7 @@ Use console_list with namespace "cache"
 | `options`        | object        | Options as key/value                           |
 | `env`            | string        | Symfony env passed as `--env`. Any name the installation defines (`dev`, `prod`, `test`, `staging`, …); `^[A-Za-z0-9_]{1,32}$` |
 | `output_file`    | string        | Write stdout to this file instead of returning it (see below) |
+| `feature_all`    | string        | `major` or `true`. Sets `FEATURE_ALL=<value>` in the command's process environment inside the target environment — `feature_all "major"` with `command "cache:clear"` is the deprecation gate `FEATURE_ALL=major bin/console cache:clear` |
 | `verbosity`      | string        | `quiet`, `normal`, `verbose`, `very-verbose`, `debug` |
 | `no_debug`       | boolean       | Disable debug mode                             |
 | `no_interaction` | boolean       | Non-interactive                                |

--- a/plugins/dev-tooling/mcp-server-php/lib/console.sh
+++ b/plugins/dev-tooling/mcp-server-php/lib/console.sh
@@ -190,13 +190,14 @@ tool_console_run() {
         verbosity: (.verbosity // null),
         no_debug: (.no_debug // null),
         no_interaction: (.no_interaction // null),
-        output_file: (.output_file // null)
+        output_file: (.output_file // null),
+        feature_all: (.feature_all // null)
     }' 2>/dev/null); then
         printf '%s\n' "Refusing to run: could not parse arguments as JSON: ${args}"
         return 1
     fi
 
-    local command arguments_json options_json env verbosity no_debug no_interaction output_file
+    local command arguments_json options_json env verbosity no_debug no_interaction output_file feature_all
     command=$(echo "${parsed}" | jq -r '.command // empty')
     arguments_json=$(echo "${parsed}" | jq -c '.arguments')
     options_json=$(echo "${parsed}" | jq -c '.options')
@@ -205,6 +206,7 @@ tool_console_run() {
     no_debug=$(echo "${parsed}" | jq -r '.no_debug // empty')
     no_interaction=$(echo "${parsed}" | jq -r '.no_interaction // empty')
     output_file=$(echo "${parsed}" | jq -r '.output_file // empty')
+    feature_all=$(echo "${parsed}" | jq -r '.feature_all // empty')
 
     if [[ -z "${command}" ]]; then
         echo "Error: 'command' parameter is required"
@@ -214,6 +216,14 @@ tool_console_run() {
     # Validate command name format (security: prevent injection)
     if [[ ! "${command}" =~ ^[a-zA-Z0-9:_-]+$ ]]; then
         echo "Error: Invalid command name format. Only alphanumeric, colons, underscores, and hyphens allowed."
+        return 1
+    fi
+
+    # This value becomes an assignment in front of the command, so it is held to
+    # the schema's enum here as well: the tool must refuse anything else even if
+    # it is reached without the validator in front of it.
+    if [[ -n "${feature_all}" && ! "${feature_all}" =~ ^(major|true)$ ]]; then
+        echo "Error: Invalid feature_all value. Only \"major\" and \"true\" are allowed."
         return 1
     fi
 
@@ -245,7 +255,7 @@ tool_console_run() {
         return 1
     fi
 
-    log "INFO" "Console run: command='${command}' args='${arg_array[*]:-}' env='${env}' verbosity='${verbosity}' output_file='${resolved_output_file}'"
+    log "INFO" "Console run: command='${command}' args='${arg_array[*]:-}' env='${env}' verbosity='${verbosity}' output_file='${resolved_output_file}' feature_all='${feature_all}'"
 
     local -a flags=()
 
@@ -314,6 +324,13 @@ tool_console_run() {
 
     local cmd="bin/console"
     [[ ${#flags[@]} -gt 0 ]] && cmd="${cmd} ${flags[*]}"
+
+    # The assignment goes inside the command string rather than in front of the
+    # wrapper process, so the shell that finally runs the command — the
+    # container's, the VM's, or the host's — is the one that applies it. Both
+    # execution paths below wrap this same string, so one placement covers them.
+    # The value is enum-bounded above and composed here, so it needs no quoting.
+    [[ -n "${feature_all}" ]] && cmd="FEATURE_ALL=${feature_all} ${cmd}"
 
     if [[ -n "${resolved_output_file}" ]]; then
         local rc=0

--- a/plugins/dev-tooling/mcp-server-php/tools.json
+++ b/plugins/dev-tooling/mcp-server-php/tools.json
@@ -164,6 +164,11 @@
             "type": "string",
             "description": "Write the command's stdout to this file instead of returning it. A relative path resolves against the project root; parent directories are created. The response then carries the resolved path, the byte count and the exit status, plus stderr. Refused when longer than 4096 bytes, or when the target exists as a symlink or a non-regular file. On a failed command the file is left untouched and stdout comes back in the response."
           },
+          "feature_all": {
+            "type": "string",
+            "enum": ["major", "true"],
+            "description": "Sets FEATURE_ALL=<value> in the console command's process environment inside the target environment. Use 'major' to run a command with the next major version's feature flags on, e.g. feature_all 'major' with command 'cache:clear' for the deprecation gate. Omit to use the installation's configured flags."
+          },
           "verbosity": {
             "type": "string",
             "enum": ["quiet", "normal", "verbose", "very-verbose", "debug"],


### PR DESCRIPTION
`console_run` on the `php-tooling` server gains an optional `feature_all` parameter, so the deprecation gate — `FEATURE_ALL=major bin/console cache:clear` — has an MCP path instead of forcing a session under MCP enforcement to drop to a raw wrapper command (`docker compose exec -T -e FEATURE_ALL=major web bin/console cache:clear`).

### `feature_all`

When the new optional parameter is present (`major` or `true`), the console command's process environment inside the target environment carries `FEATURE_ALL=<value>`. The assignment is prefixed inside the wrapped command string (`FEATURE_ALL=major bin/console …`) rather than placed in front of the wrapper process, so the shell that finally runs the command — the container's, the VM's, or the host's — is the one that applies it: docker, docker-compose, and vagrant embed the string in a remote `bash -c`, native evals it locally, and ddev rejoins its argv through the container's `bash -c`. The parameter combines freely with the existing surface — `feature_all: "major"` plus `command: "cache:clear"` is the deprecation gate in one call, including `env` and `output_file`.

The enum is the whole accepted surface, and no generic env-var map is added: arbitrary names and values would reach the wrapped shell as caller-controlled strings, so a future variable gets another named, enum-bounded parameter. The value is enforced by the vendored schema validator and again inside `tool_console_run()` for a call that reaches the tool without the validator in front, so nothing new reaches a shell unquoted. The template-synced `shared/` layer is untouched; the prefix lives in `console.sh`'s command construction.

### Limits

The prefix is asserted through the real `wrap_command` for the native and docker-compose environment types (docker-compose with its call-time container/workdir resolution stubbed); docker, vagrant, and ddev rest on reading `wrap_command`, not on tests. That `FEATURE_ALL=major` actually flips flag state in a live Shopware is taken from the flag's documented behavior rather than re-measured — no container ran during development.